### PR TITLE
Defining static webhook subscriptions in ZCML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - pypy3
 script:
   - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+  - coverage run -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
 env:
   global:
     - PYTHONHASHSEED=1042466059

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ notifications:
 install:
   - pip install -U pip setuptools
   - pip install -U coveralls coverage
-  - pip install -U -e ".[test]"
+  - pip install -U -e ".[test,docs]"
 
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ script:
 env:
   global:
     - PYTHONHASHSEED=1042466059
-    # Not yet. https://github.com/NextThought/nti.externalization/pull/108
-    # - ZOPE_INTERFACE_STRICT_IRO=1
+    - ZOPE_INTERFACE_STRICT_IRO=1
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ python:
 script:
   - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
 env:
-    global:
-        - PYTHONHASHSEED=1042466059
+  global:
+    - PYTHONHASHSEED=1042466059
+    # Not yet. https://github.com/NextThought/nti.externalization/pull/108
+    # - ZOPE_INTERFACE_STRICT_IRO=1
 
 after_success:
   - coveralls

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,8 @@ limited to:
   here.
 - Providing a user interface or HTTPS API for viewing webhook audit
   logs.
+- Enabling webhooks to fire only for specific objects. This package
+  deals with scopes (sites) and kinds of objects, not individual instances.
 
 In Scope/Features
 =================

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,16 @@
 ==============
 
 .. image:: https://travis-ci.org/NextThought/nti.webhooks.svg?branch=master
-    :target: https://travis-ci.org/NextThought/nti.webhooks
+   :target: https://travis-ci.org/NextThought/nti.webhooks
 
 .. image:: https://coveralls.io/repos/github/NextThought/nti.webhooks/badge.svg?branch=master
-    :target: https://coveralls.io/github/NextThought/nti.webhooks?branch=master
+   :target: https://coveralls.io/github/NextThought/nti.webhooks?branch=master
+
+.. image:: https://readthedocs.org/projects/ntiwebhooks/badge/?version=latest
+   :target: https://ntiwebhooks.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
+.. sphinx-include-begin
 
 This package provides the infrastructure and delivery mechanisms for a
 server to support webhook delivery. For complete details and the

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,7 @@
+===============
+ API Reference
+===============
+
+.. toctree::
+
+   interfaces

--- a/docs/api/interfaces.rst
+++ b/docs/api/interfaces.rst
@@ -1,0 +1,5 @@
+=========================
+ nti.webhooks.interfaces
+=========================
+
+.. automodule:: nti.webhooks.interfaces

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -364,7 +364,10 @@ intersphinx_mapping = {
     'https://zopesite.readthedocs.io/en/latest/': None,
     'https://zopetraversing.readthedocs.io/en/latest/': None,
     'https://zopelifecycleevent.readthedocs.io/en/latest/': None,
+    'https://zopesecurity.readthedocs.io/en/latest/': None,
+    'https://zopeprincipalregistry.readthedocs.io/en/latest/': None,
     'https://ntitesting.readthedocs.io/en/latest/': None,
+    'https://ntischema.readthedocs.io/en/latest/': None,
 }
 
 extlinks = {'issue': ('https://github.com/NextThought/nti.webhooks/issues/%s',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -363,6 +363,7 @@ intersphinx_mapping = {
     'https://zopecomponent.readthedocs.io/en/latest/': None,
     'https://zopesite.readthedocs.io/en/latest/': None,
     'https://zopetraversing.readthedocs.io/en/latest/': None,
+    'https://zopelifecycleevent.readthedocs.io/en/latest/': None,
     'https://ntitesting.readthedocs.io/en/latest/': None,
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -361,6 +361,7 @@ intersphinx_mapping = {
     'https://zodb-docs.readthedocs.io/en/latest/': None,
     'https://zopeinterface.readthedocs.io/en/latest/': None,
     'https://zopecomponent.readthedocs.io/en/latest/': None,
+    'https://zopecontainer.readthedocs.io/en/latest/': None,
     'https://zopesite.readthedocs.io/en/latest/': None,
     'https://zopetraversing.readthedocs.io/en/latest/': None,
     'https://zopelifecycleevent.readthedocs.io/en/latest/': None,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -359,14 +359,17 @@ texinfo_documents = [
 intersphinx_mapping = {
     'https://docs.python.org/': None,
     'https://zodb-docs.readthedocs.io/en/latest/': None,
-    'https://zopeinterface.readthedocs.io/en/latest/': None,
+
+    'https://zopeauthentication.readthedocs.io/en/latest/': None,
     'https://zopecomponent.readthedocs.io/en/latest/': None,
     'https://zopecontainer.readthedocs.io/en/latest/': None,
+    'https://zopeinterface.readthedocs.io/en/latest/': None,
+    'https://zopelifecycleevent.readthedocs.io/en/latest/': None,
+    'https://zopeprincipalregistry.readthedocs.io/en/latest/': None,
+    'https://zopesecurity.readthedocs.io/en/latest/': None,
     'https://zopesite.readthedocs.io/en/latest/': None,
     'https://zopetraversing.readthedocs.io/en/latest/': None,
-    'https://zopelifecycleevent.readthedocs.io/en/latest/': None,
-    'https://zopesecurity.readthedocs.io/en/latest/': None,
-    'https://zopeprincipalregistry.readthedocs.io/en/latest/': None,
+
     'https://ntitesting.readthedocs.io/en/latest/': None,
     'https://ntischema.readthedocs.io/en/latest/': None,
 }

--- a/docs/customizing_payloads.rst
+++ b/docs/customizing_payloads.rst
@@ -1,0 +1,7 @@
+======================
+ Customizing Payloads
+======================
+
+- Talk about writing dialects.
+- Talk about adapting ``event.object`` to ``IWebhookPayload`` (and
+  actually write that).

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -20,3 +20,18 @@
       history`.
 
       .. seealso:: :class:`~.IWebhookSubscription`
+
+   active
+      Of a subscription: An existing subscription is active if it
+      is ready to accept webhook deliveries. Contrast with
+      :term:`inactive`. A subscription in this state may transaction
+      to inactive at any time.
+
+   inactive
+      Of a subscription: An existing subscription is inactive if
+      webhook deliviries will no longer be attempted to it. It may
+      transaction back to :term:`active` at any time.
+
+   applicable
+      Of a subscription: Does the subscription apply to some piece of
+      data, including permission checks?

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,0 +1,22 @@
+.. _glossary:
+
+==========
+ Glossary
+==========
+
+.. glossary::
+   :sorted:
+
+
+   subscription
+      A target to which webhooks will be delivered.
+
+      Subscriptions may be either :term:`active` or :term:`inactive`.
+      Only active subscriptions will result in delivery attempts.
+
+      In addition to capturing the target URL and HTTP method to use,
+      a subscription knows the :term:`dialect` to use, along with the
+      security restrictions to apply. It also has a :term:`delivery
+      history`.
+
+      .. seealso:: :class:`~.IWebhookSubscription`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Contents:
 
    glossary
    static
+   api/index
    changelog
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Contents:
    glossary
    static
    security
+   customizing_payloads
    api/index
    changelog
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Contents:
 
    glossary
    static
+   security
    api/index
    changelog
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,15 @@ Contents:
 .. toctree::
    :maxdepth: 1
 
+   glossary
+   static
    changelog
 
+
+.. note:: See the :doc:`glossary` for common terminology.
+
+.. include:: ../README.rst
+   :start-after: sphinx-include-begin
 
 ====================
  Indices and tables

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -33,8 +33,11 @@ of the directive).
    hierarchy but mean two completely different principals, that is a
    valid possibility.)
 
-If no principal can be found, the subscription will not be
-:term:`applicable` and no delivery will be attempted.
+If no principal can be found, the unauthenticated (anonymous)
+principal will be used instead; depending on the security policy and
+permission structure in use, the subscription may or may not be
+:term:`applicable`.
+
 
 Permissions
 ===========

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,0 +1,122 @@
+=================
+ Security Checks
+=================
+
+In :doc:`static`, we discussed how to use ZCML to register for webhook
+deliveries when certain events on certain resources happen.
+Conspicuously absent from that discussion was any mention of two of
+the more interesting and important attributes of the :class:`ZCML
+directive <nti.webhooks.zcml.IStaticSubscriptionDirective>`:
+``owner`` and ``permission``. This document will fill in those
+details.
+
+Owners
+======
+
+Owners, for both static subscriptions and other types of
+subscriptions, are strings naming a :mod:`IPrincipal
+<zope.security.interfaces>` as defined in
+:mod:`zope.security.interfaces`. At runtime, the string is turned into
+an ``IPrincipal`` object using
+:meth:`zope.authentication.interfaces.IAuthentication.getPrincipal`
+from the :mod:`IAuthentication <zope.authentication.interfaces>`
+utility *closest to the object of the event* (i.e., the ``for`` part
+of the directive).
+
+.. note::
+
+   ``IAuthentication`` utilities are usually arranged
+   into a hierarchy related to the object hierarchy, and principals may
+   exist in some parts of the tree and not in others. (While steps such
+   as prefixing the principal ID are usually taken to avoid having the
+   same principal ID be valid in two different parts of the site
+   hierarchy but mean two completely different principals, that is a
+   valid possibility.)
+
+If no principal can be found, the subscription will not be
+:term:`applicable` and no delivery will be attempted.
+
+Permissions
+===========
+
+Permissions are defined by :mod:`IPermission
+<zope.security.interfaces>`, but the important part is how they are
+checked.
+
+The :mod:`ISecurityPolicy <zope.security.interfaces>` is used to
+produce an ``IInteraction`` object. The ``IInteraction`` is then asked
+to confirm the permission using its ``checkPermission(permission,
+object)`` method. Normally, the security policy is a global object,
+and there can only be one active interaction at a time, but temporary,
+sub-interactions are possible. This module follows that model.
+
+.. important::
+
+   When creating the temporary interactions to check permissions, this
+   module will use the global security policy to create an interaction
+   containing *two* participations: one for the principal found
+   relating to the object, and one for the principal that was
+   previously participating, if there was one. In this way, the
+   permission must be allowed to both the *initiator* of the action
+   (the logged in user) as well as the owner of the subscription.
+
+Example
+=======
+
+Lets put these pieces together and check how security applies.
+
+We'll begin by defining the same subscription we used :doc:`previously
+<static>`, but we'll add a permission and an owner. We'll use
+:mod:`zope.principalregistry` to provide a global ``IAuthentication``
+utility and a defined principal:
+
+.. doctest::
+
+   >>> from zope.configuration import xmlconfig
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="zope.component" />
+   ...   <include package="zope.container" />
+   ...   <include package="zope.principalregistry" />
+   ...   <include package="zope.principalregistry" file="meta.zcml" />
+   ...   <include package="nti.webhooks" />
+   ...   <principal
+   ...         id="zope.manager"
+   ...         title="Manager"
+   ...         description="System Manager"
+   ...         login="admin"
+   ...         password_manager="SHA1"
+   ...         password="40bd001563085fc35165329ea1ff5c5ecbdbbeef"
+   ...         />
+   ...   <webhooks:staticSubscription
+   ...             to="https://this_domain_does_not_exist"
+   ...             for="zope.container.interfaces.IContentContainer"
+   ...             when="zope.lifecycleevent.interfaces.IObjectCreatedEvent"
+   ...             permission="zope.View"
+   ...             owner="zope.manager" />
+   ... </configure>
+   ... """)
+
+Next, we can find the :term:`active` subscription, just as before:
+
+   >>> from nti.webhooks.subscribers import find_active_subscriptions_for
+   >>> from zope.container.folder import Folder
+   >>> from zope.lifecycleevent import ObjectCreatedEvent
+   >>> event = ObjectCreatedEvent(Folder())
+   >>> len(find_active_subscriptions_for(event.object, event))
+   1
+   >>> find_active_subscriptions_for(event.object, event)
+   [<...Subscription ... to='https://this_domain_does_not_exist' for=IContentContainer when=IObjectCreatedEvent>]
+
+
+Next, we need to know if the subscription is :term:`applicable` to the
+data. Unlike before, since we have security constraints in place, the subscription is *not* applicable:
+
+.. doctest::
+
+   >>> subscriptions = find_active_subscriptions_for(event.object, event)
+   >>> [subscription.isApplicable(event.object) for subscription in subscriptions]
+   [False]

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -207,3 +207,10 @@ permission check will fail.
    >>> with interaction('some.one.else'):
    ...    [subscription.isApplicable(event.object) for subscription in subscriptions]
    [False]
+
+
+
+.. testcleanup::
+
+   from zope.testing import cleanup
+   cleanup.cleanUp()

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -121,8 +121,11 @@ Now that we have that in place, let's verify that it exists:
    >>> sub_manager = component.getUtility(IWebhookSubscriptionManager)
    >>> len(list(sub_manager))
    1
-   >>> list(sub_manager.items())
-   [('Subscription', <...Subscription ... to='https://this_domain_does_not_exist' for=IContentContainer when=IObjectCreatedEvent>)]
+   >>> items = list(sub_manager.items())
+   >>> print(items[0][0])
+   Subscription
+   >>> items[0][1]
+   <...Subscription ... to='https://this_domain_does_not_exist' for=IContentContainer when=IObjectCreatedEvent>
 
 And we'll verify that it is :term:`active`, by looking for it using
 the event we just declared:
@@ -189,8 +192,8 @@ But it does record a failed attempt in the subscription:
    >>> attempt = list(subscription.values())[0]
    >>> attempt.status
    'failed'
-   >>> attempt.message
-   '[Errno 8] nodename nor servname provided, or not known'
+   >>> print(attempt.message)
+   Verification of the destination URL failed. Please check the domain.
 
 
 
@@ -266,8 +269,8 @@ finish, and then we can examine our delivery attempt:
    >>> attempt = list(subscription.values())[0]
    >>> attempt.status
    'successful'
-   >>> attempt.message
-   '200 OK'
+   >>> print(attempt.message)
+   200 OK
 
 
 .. _z3c.baseregistry: https://github.com/zopefoundation/z3c.baseregistry/tree/master/src/z3c/baseregistry

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -54,25 +54,6 @@ deliveries.
 
 There is only one required argument: the destination URL.
 
-.. doctest::
-
-   >>> conf_context = xmlconfig.string("""
-   ... <configure
-   ...     xmlns="http://namespaces.zope.org/zope"
-   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
-   ...     >
-   ...   <webhooks:staticSubscription to="https://example.com" />
-   ... </configure>
-   ... """, conf_context)
-
-.. clean up that registration; it won't work yet.
-
-.. doctest::
-   :hide:
-
-   >>> from zope.testing import cleanup
-   >>> cleanup.cleanUp()
-
 The destination must be HTTPS.
 
 .. doctest::
@@ -91,14 +72,55 @@ The destination must be HTTPS.
        File "<string>", line 6.2-6.57
        zope.schema.interfaces.InvalidURI: http://example.com
 
-The above registration will try to send *all* ``IObjectEvent`` events
-for *all* objects (that implement an interface) to
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <webhooks:staticSubscription to="https://example.com" />
+   ... </configure>
+   ... """, conf_context)
+
+.. clean up that registration, we don't actually want it
+
+.. doctest::
+   :hide:
+
+   >>> from zope.testing import cleanup
+   >>> cleanup.cleanUp()
+
+If we specify a permission to check, it must exist.
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <webhooks:staticSubscription
+   ...             to="https://example.com"
+   ...             permission="no.such.permission" />
+   ... </configure>
+   ... """, conf_context)
+   Traceback (most recent call last):
+   ...
+   zope.configuration.config.ConfigurationExecutionError: File "<string>", line 6.2-8.46
+     Could not read source.
+       ValueError: ('Undefined permission ID', 'no.such.permission')
+
+
+The above (successful) registration will try to send *all* ``IObjectEvent`` events
+for all objects that implement :class:`~nti.webhooks.interfaces.IWebhookPayload` to
 ``https://example.com`` using the default dialect. That's unlikely to
 be what you want, outside of tests. Instead, you'll want to limit the
 event to particular kinds of objects, and particular events in their
 lifecycle. The ``for`` and ``when`` attributes let you do that. Here,
 we'll give a comple example saying that whenever a new
-:class:`zope.container.interfaces.IContainer` is created, we'd like to
+:mod:`IContainer <zope.container.interfaces>` is created, we'd like to
 deliver a webhook.
 
 .. doctest::
@@ -118,7 +140,7 @@ deliver a webhook.
    ... </configure>
    ... """)
 
-Now that we have that in place, lets attempt to deliver a webhook.
+Now that we have that in place, let's attempt to deliver a webhook.
 First, we'll send something that doesn't match our criteria and notice
 nothing happens:
 

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -80,8 +80,8 @@ If we specify a permission to check, it must exist.
 .. doctest::
    :hide:
 
-   from zope.testing import cleanup
-   cleanup.cleanUp()
+   >>> from zope.testing import cleanup
+   >>> cleanup.cleanUp()
 
 
 The above (successful) registration will try to send *all* ``IObjectEvent`` events
@@ -118,6 +118,8 @@ Now that we have that in place, let's verify that it exists:
    >>> from nti.webhooks.interfaces import IWebhookSubscriptionManager
    >>> from zope import component
    >>> sub_manager = component.getUtility(IWebhookSubscriptionManager)
+   >>> len(list(sub_manager))
+   1
    >>> list(sub_manager.items())
    [('Subscription', <...Subscription ... {'to': 'https://this_domain_does_not_exist', 'for_': <InterfaceClass ...IContentContainer>, 'when': <InterfaceClass ...IObjectCreatedEvent>...
 
@@ -181,8 +183,10 @@ But it does record a failed attempt in the subscription:
 .. doctest::
 
    >>> subscription = sub_manager['Subscription']
+   >>> len(subscription)
+   1
    >>> list(subscription.values())
-   [<...FailedDeliveryAttempt...>]
+   [<...WebhookDeliveryAttempt...'status': 'failed'...>]
 
 .. _z3c.baseregistry: https://github.com/zopefoundation/z3c.baseregistry/tree/master/src/z3c/baseregistry
 

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -1,0 +1,16 @@
+==============================
+ Static Webhook Subscriptions
+==============================
+
+.. currentmodule:: nti.webhooks.zcml
+
+The simplest type of webhook :term:`subscription` is one that is
+configured statically, typically at application startup time. This
+package provides ZCML directives to facilitate this. The directives
+can either be used globally, creating subscriptions that are valid
+across the entire application, or can be scoped to a smaller portion
+of the application using `z3c.baseregistry`_.
+
+.. autointerface:: IStaticSubscriptionDirective
+
+.. _z3c.baseregistry: https://github.com/zopefoundation/z3c.baseregistry/tree/master/src/z3c/baseregistry

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -188,8 +188,11 @@ But it does record a failed attempt in the subscription:
    >>> list(subscription.values())
    [<...WebhookDeliveryAttempt...'status': 'failed'...>]
 
-.. _z3c.baseregistry: https://github.com/zopefoundation/z3c.baseregistry/tree/master/src/z3c/baseregistry
 
+Let's reset things and look at what a successful delivery might look like.
+
+
+.. _z3c.baseregistry: https://github.com/zopefoundation/z3c.baseregistry/tree/master/src/z3c/baseregistry
 
 
 .. testcleanup::

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -145,6 +145,8 @@ the event we just declared:
 Next, we need to know if the subscription is :term:`applicable` to the
 data. Since we didn't specify a permission or a principal to check, the subscription is applicable:
 
+.. seealso:: :doc:`security` for information on security checks.
+
 .. doctest::
 
    >>> subscriptions = find_active_subscriptions_for(event.object, event)

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -13,4 +13,81 @@ of the application using `z3c.baseregistry`_.
 
 .. autointerface:: IStaticSubscriptionDirective
 
+
+Let's look at an example of how to use this directive from ZCML. We
+need to define the XML namespace it's in, and we need to include the
+configuration file that defines it:
+
+.. doctest::
+
+   >>> from zope.configuration import xmlconfig
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...    <include package="nti.webhooks" file="meta.zcml" />
+   ... </configure>
+   ... """)
+
+Once that's done, we can use the ``webhooks:staticSubscription`` XML
+tag to define a subscription to start receiving our webhook
+deliveries.
+
+There is only one required argument: the destination URL.
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <webhooks:staticSubscription to="https://example.com" />
+   ... </configure>
+   ... """, conf_context)
+
+The destination must be HTTPS.
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <webhooks:staticSubscription to="http://example.com" />
+   ... </configure>
+   ... """, conf_context)
+   Traceback (most recent call last):
+   ...
+   zope.configuration.exceptions.ConfigurationError: Invalid value for 'to'
+       File "<string>", line 6.2-6.57
+       zope.schema.interfaces.InvalidURI: http://example.com
+
+
+The above registration will try to send *all* ``IObjectEvent`` events
+for *all* objects (that implement an interface) to
+``https://example.com`` using the default dialect. That's unlikely to
+be what you want, outside of tests. Instead, you'll want to limit the
+event to particular kinds of objects, and particular events in their
+lifecycle. The ``for`` and ``when`` attributes let you do that. Here,
+we'll say that whenever a new :class:`zope.container.interfaces.IContainer`
+is created, we'd like to deliver a webhook.
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <webhooks:staticSubscription
+   ...             to="https://example.com"
+   ...             for="zope.container.interfaces.IContainer"
+   ...             when="zope.lifecycleevent.interfaces.IObjectCreatedEvent" />
+   ... </configure>
+   ... """, conf_context)
+
+
 .. _z3c.baseregistry: https://github.com/zopefoundation/z3c.baseregistry/tree/master/src/z3c/baseregistry

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ setup(
     install_requires=[
         'zope.authentication', # IAuthentication
         'zope.interface >= 5.1',
+        'zope.container',
+        'zope.lifecycleevent',
         'zope.event',
         'zope.security', # IPrincipal, Permission
         'zope.principalregistry', # TextId

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,13 @@ setup(
     package_dir={'': 'src'},
     namespace_packages=['nti'],
     install_requires=[
+        'zope.authentication', # IAuthentication
         'zope.interface >= 5.1',
         'zope.event',
+        'zope.security', # IPrincipal, Permission
+        'zope.principalregistry', # TextId
+        'nti.externalization >= 1.1.3',
+        'nti.schema',
         'setuptools',
         'transaction',
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ TESTS_REQUIRE = [
     'nti.testing',
     'zope.testrunner',
     'zope.lifecycleevent',
+    'zope.securitypolicy', # ZCML directives for granting/denying
     # Easy mocking of ``requests``.
     'responses',
 ]

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'zope.container',
         'zope.security', # IPrincipal, Permission
         'zope.principalregistry', # TextId
+        'zope.componentvocabulary',
         'nti.externalization >= 1.1.3',
         'nti.schema',
         'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(
     package_dir={'': 'src'},
     namespace_packages=['nti'],
     install_requires=[
+        # backport of concurrent.futures; implements the 3.7
+        # interface.
+        'futures; python_version == "2.7"',
         'zope.authentication', # IAuthentication
         'zope.interface >= 5.1',
         'zope.container',

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ TESTS_REQUIRE = [
     'nti.testing',
     'zope.testrunner',
     'zope.lifecycleevent',
+    # Easy mocking of ``requests``.
+    'responses',
 ]
 
 def _read(fname):
@@ -61,7 +63,7 @@ setup(
         'zope.componentvocabulary',
         'zope.vocabularyregistry',
         'zope.site',
-        'nti.externalization >= 1.1.3',
+        'nti.externalization >= 2.0.0', # Consistent interface resolution order
         'nti.schema',
         'setuptools',
         'transaction',

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ setup(
         'zope.security', # IPrincipal, Permission
         'zope.principalregistry', # TextId
         'zope.componentvocabulary',
+        'zope.vocabularyregistry',
+        'zope.site',
         'nti.externalization >= 1.1.3',
         'nti.schema',
         'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ TESTS_REQUIRE = [
     'coverage',
     'nti.testing',
     'zope.testrunner',
+    'zope.lifecycleevent',
 ]
 
 def _read(fname):
@@ -55,8 +56,6 @@ setup(
         'zope.authentication', # IAuthentication
         'zope.interface >= 5.1',
         'zope.container',
-        'zope.lifecycleevent',
-        'zope.event',
         'zope.security', # IPrincipal, Permission
         'zope.principalregistry', # TextId
         'nti.externalization >= 1.1.3',
@@ -72,6 +71,6 @@ setup(
             'Sphinx',
             'sphinx_rtd_theme',
             'repoze.sphinx.autointerface',
-        ],
+        ] + TESTS_REQUIRE,
     },
 )

--- a/src/nti/webhooks/__init__.py
+++ b/src/nti/webhooks/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""
+
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from zope.i18nmessageid import MessageFactory as _Factory
+MessageFactory = _Factory('nti.webhooks')

--- a/src/nti/webhooks/_schema.py
+++ b/src/nti/webhooks/_schema.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+Schema fields used internally.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from zope.configuration.fields import GlobalInterface
+from zope.schema import InterfaceField
+from zope.schema.interfaces import NotAnInterface
+from zope.schema.interfaces import InvalidURI
+
+from zope.interface.interfaces import IObjectEvent
+
+from nti.schema.field import ValidURI
+
+# pylint:disable=inherit-non-class
+
+class NotAnObjectEvent(NotAnInterface):
+    """
+    Raised when the interface is not for an IObjectEvent.
+    """
+
+
+class ObjectEventField(InterfaceField):
+    """
+    A field that requires an interface that is a kind of ``IObjectEvent``.
+    """
+    def _validate(self, value):
+        super(ObjectEventField, self)._validate(value)
+        if not value.isOrExtends(IObjectEvent):
+            raise NotAnObjectEvent(
+                value,
+                self.__name__
+            ).with_field_and_value(self, value)
+
+
+class ObjectEventInterface(GlobalInterface):
+    """
+    A configuration field that looks up a named ``IObjectEvent``
+    interface.
+    """
+    def __init__(self, **kwargs):
+        super(ObjectEventInterface, self).__init__(**kwargs)
+        self.value_type = ObjectEventField()
+
+
+class HTTPSURL(ValidURI):
+    """
+    A URI that's HTTPS only.
+
+    As opposed to nti.schema.field.HTTPURL, this:
+
+    - allows for a port
+    - allows for inline authentication (``https://user:pass@host/path/``)
+    - Requires the URL scheme to be specified, and requires it to be HTTPS.
+
+    TODO: Move all those capabilities to nti.schema.
+    """
+
+    def _validate(self, value):
+        super(HTTPSURL, self)._validate(value)
+        if not value.lower().startswith('https://'):
+            raise InvalidURI(value).with_field_and_value(self, value)

--- a/src/nti/webhooks/attempts.py
+++ b/src/nti/webhooks/attempts.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+Webhook delivery attempts.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import time
+
+from persistent import Persistent
+from zope.interface import implementer
+from zope.schema.fieldproperty import createFieldProperties
+
+from nti.externalization.representation import WithRepr
+from nti.schema.fieldproperty import createDirectFieldProperties
+from nti.schema.schema import SchemaConfigured
+
+from nti.webhooks.interfaces import IWebhookDeliveryAttempt
+
+
+@WithRepr
+@implementer(IWebhookDeliveryAttempt)
+class WebhookDeliveryAttempt(SchemaConfigured):
+    createFieldProperties(IWebhookDeliveryAttempt)
+
+    def __init__(self, **kwargs):
+        self.createdTime = self.lastModified = time.time()
+        SchemaConfigured.__init__(self, **kwargs)
+
+
+class PersistentWebhookDeliveryAttempt(WebhookDeliveryAttempt, Persistent):
+    pass

--- a/src/nti/webhooks/attempts.py
+++ b/src/nti/webhooks/attempts.py
@@ -17,16 +17,43 @@ from zope.container.contained import Contained
 from nti.schema.schema import SchemaConfigured
 
 from nti.webhooks.interfaces import IWebhookDeliveryAttempt
+from nti.webhooks.interfaces import IWebhookDeliveryAttemptRequest
+from nti.webhooks.interfaces import IWebhookDeliveryAttemptResponse
 
+# Requests and responses are immutable. Thus they are never
+# persistent.
 
-@implementer(IWebhookDeliveryAttempt)
-class WebhookDeliveryAttempt(SchemaConfigured, Contained):
-    status = None
-    createFieldProperties(IWebhookDeliveryAttempt)
+class _Base(SchemaConfigured):
 
     def __init__(self, **kwargs):
         self.createdTime = self.lastModified = time.time()
-        SchemaConfigured.__init__(self, **kwargs)
+        super(_Base, self).__init__(**kwargs)
+
+@implementer(IWebhookDeliveryAttemptRequest)
+class WebhookDeliveryAttemptRequest(_Base):
+    __name__ = 'request'
+    createFieldProperties(IWebhookDeliveryAttemptRequest)
+
+@implementer(IWebhookDeliveryAttemptResponse)
+class WebhookDeliveryAttemptResponse(_Base):
+    __name__ = 'response'
+    createFieldProperties(IWebhookDeliveryAttemptResponse)
+
+
+@implementer(IWebhookDeliveryAttempt)
+class WebhookDeliveryAttempt(_Base, Contained):
+    status = None
+    createFieldProperties(IWebhookDeliveryAttempt)
+    # Allow delayed validation for these things.
+    request = None
+    response = None
+
+    def __init__(self, **kwargs):
+        super(WebhookDeliveryAttempt, self).__init__(**kwargs)
+        if self.request is None:
+            self.request = WebhookDeliveryAttemptRequest()
+        if self.response is None:
+            self.response = WebhookDeliveryAttemptResponse()
 
     def __repr__(self):
         return "<%s.%s at 0x%x status=%r>" % (

--- a/src/nti/webhooks/attempts.py
+++ b/src/nti/webhooks/attempts.py
@@ -14,22 +14,28 @@ from zope.interface import implementer
 from zope.schema.fieldproperty import createFieldProperties
 from zope.container.contained import Contained
 
-from nti.externalization.representation import WithRepr
-from nti.schema.fieldproperty import createDirectFieldProperties
 from nti.schema.schema import SchemaConfigured
 
 from nti.webhooks.interfaces import IWebhookDeliveryAttempt
 
 
-@WithRepr
 @implementer(IWebhookDeliveryAttempt)
 class WebhookDeliveryAttempt(SchemaConfigured, Contained):
+    status = None
     createFieldProperties(IWebhookDeliveryAttempt)
 
     def __init__(self, **kwargs):
         self.createdTime = self.lastModified = time.time()
         SchemaConfigured.__init__(self, **kwargs)
 
+    def __repr__(self):
+        return "<%s.%s at 0x%x status=%r>" % (
+            self.__class__.__module__,
+            self.__class__.__name__,
+            id(self),
+            self.status,
+        )
 
 class PersistentWebhookDeliveryAttempt(WebhookDeliveryAttempt, Persistent):
+    # XXX: _p_repr
     pass

--- a/src/nti/webhooks/attempts.py
+++ b/src/nti/webhooks/attempts.py
@@ -12,6 +12,7 @@ import time
 from persistent import Persistent
 from zope.interface import implementer
 from zope.schema.fieldproperty import createFieldProperties
+from zope.container.contained import Contained
 
 from nti.externalization.representation import WithRepr
 from nti.schema.fieldproperty import createDirectFieldProperties
@@ -22,7 +23,7 @@ from nti.webhooks.interfaces import IWebhookDeliveryAttempt
 
 @WithRepr
 @implementer(IWebhookDeliveryAttempt)
-class WebhookDeliveryAttempt(SchemaConfigured):
+class WebhookDeliveryAttempt(SchemaConfigured, Contained):
     createFieldProperties(IWebhookDeliveryAttempt)
 
     def __init__(self, **kwargs):

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -32,7 +32,7 @@
     <utility factory=".destination_validator.DefaultDestinationValidator" />
 
     <!-- The default delivery manager -->
-    <utility factory=".delivery_manager.DefaultDeliveryManager" />
+    <utility factory=".delivery_manager.getGlobalDeliveryManager" />
 
     <!-- The default dialect -->
     <utility factory=".dialect.DefaultWebhookDialect" />

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -1,0 +1,29 @@
+<!-- -*- mode: nxml -*- -->
+<configure  xmlns="http://namespaces.zope.org/zope"
+            xmlns:i18n="http://namespaces.zope.org/i18n"
+            xmlns:zcml="http://namespaces.zope.org/zcml"
+            xmlns:meta="http://namespaces.zope.org/meta">
+
+    <include package="zope.component" file="meta.zcml" />
+    <include package="." file="meta.zcml" />
+
+    <include package="zope.component" />
+    <include package="zope.container" />
+    <!-- make vocabularies go through zope.component -->
+    <include package="zope.vocabularyregistry" />
+    <!-- Permission vocabularies themselves -->
+    <include package="zope.security" />
+
+    <!-- Other helpful zope.component vocabs -->
+    <include package="zope.componentvocabulary" />
+
+    <!-- Needed to turn arbitrary objects into IComponentLookup, -->
+    <!-- which is done when finding vocabularies -->
+    <include package="zope.site" />
+
+    <!-- The global subscription manager -->
+    <utility component=".subscriptions.global_subscription_manager"
+             provides=".interfaces.IWebhookSubscriptionManager" />
+
+
+</configure>

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -21,9 +21,23 @@
     <!-- which is done when finding vocabularies -->
     <include package="zope.site" />
 
+    <!-- Basic externalization support -->
+    <include package="nti.externalization" />
+
+
     <!-- The global subscription manager -->
     <utility component=".subscriptions.global_subscription_manager"
              provides=".interfaces.IWebhookSubscriptionManager" />
 
 
+    <!-- Global event dispatcher -->
+    <subscriber
+        for="* zope.interface.interfaces.IObjectEvent"
+        handler=".subscribers.dispatch_webhook_event"
+        trusted="true"
+        />
+
+
+    <!-- The default dialect -->
+    <utility factory=".dialect.DefaultWebhookDialect" />
 </configure>

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -24,11 +24,18 @@
     <!-- Basic externalization support -->
     <include package="nti.externalization" />
 
-
     <!-- The global subscription manager -->
     <utility component=".subscriptions.global_subscription_manager"
              provides=".interfaces.IWebhookSubscriptionManager" />
 
+    <!-- The default validator -->
+    <utility factory=".destination_validator.DefaultDestinationValidator" />
+
+    <!-- The default delivery manager -->
+    <utility factory=".delivery_manager.DefaultDeliveryManager" />
+
+    <!-- The default dialect -->
+    <utility factory=".dialect.DefaultWebhookDialect" />
 
     <!-- Global event dispatcher -->
     <subscriber
@@ -38,6 +45,4 @@
         />
 
 
-    <!-- The default dialect -->
-    <utility factory=".dialect.DefaultWebhookDialect" />
 </configure>

--- a/src/nti/webhooks/datamanager.py
+++ b/src/nti/webhooks/datamanager.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""
+The data manager is the active core of this package.
+
+It's responsible for integrating with the transaction machinery to
+schedule the sending of data.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import socket
+
+from zope import component
+from zope.interface import implementer
+from transaction.interfaces import IDataManager
+
+from nti.webhooks.interfaces import IWebhookDialect
+
+def foreign_transaction(func):
+    @functools.wraps(func)
+    def dec(self, transaction):
+        if self.transaction and self.transaction is not transaction:
+            raise ValueError("Foreign transaction")
+        func(self, transaction)
+
+    return dec
+
+@implementer(IDataManager)
+class WebhookDataManager(object):
+
+    transaction = None
+    _voted_data = None
+
+    def __init__(self, transaction_manager, data, event, subscriptions):
+        """
+        :param transaction_manager: The current ``ITransactionManager`` we are joining.
+        :param subscriptions: A sequence of ``IWebhookSubscription`` objects to
+           join to the transaction. More may be added later, up until the time
+           the transaction begins to commit. They will be de-duplicated at the last
+           possible moment. This object does not check for them being active or even applicable;
+           once they are joined to the transaction, they will be delivered.
+        """
+        self.transaction_manager = transaction_manager
+        self._subscriptions = {(data, event): list(subscriptions)}
+
+    def add_subscriptions(self, data, event, subscriptions):
+        """
+        Add more subscriptions to the set managed by this object.
+
+        Once two-phase-commit begins, this method is forbidden.
+
+        TODO We may need a mechanism to say, if we got multiple event types for a single
+        object, when and how to coalesce them. For example, given ObjectCreated and ObjectAdded
+        events, we probably only want to broadcast one of them. This may be dialect specific?
+        Or part of the subscription registration? A priority or 'supercedes' or something?
+        For now, we just count on people not registering events that way.
+        """
+        if self.transaction:
+            raise ValueError("Already in transaction")
+        try:
+            self._subscriptions[(data, event)].extend(subscriptions)
+        except KeyError:
+            self._subscriptions[(data, event)] = list(subscriptions)
+
+
+    @foreign_transaction
+    def tpc_begin(self, transaction):
+        self.transaction = transaction
+
+    @foreign_transaction
+    def tpc_vote(self, transaction):
+        # Be sure we can find all the dialects.
+        # Note that dialects may mean different things to different subscriptions.
+        all_subscriptions = []
+        for v in self._subscriptions.values():
+            all_subscriptions.extend(v)
+
+        dialects = {
+            sub: component.getUtility(IWebhookDialect, sub.dialect_id or u'', sub)
+            for sub in all_subscriptions
+        }
+        # Be sure we can find host names.
+        hosts = {sub.netloc for sub in all_subscriptions}
+        broken_hosts = set()
+        for host in hosts:
+            # TODO: gevent paralleize these?
+            try:
+                socket.getaddrinfo(host, None)
+            except socket.error:
+                broken_hosts.add(host)
+
+        # Be sure we can serialize the data for each (distinct) dialect.
+        serialized_data_by_dialect = {} # (dialect, data) -> data string
+        serialized_data_by_sub = [] # (subscription, dialect, serialized_data)
+        for (data, _event), subscriptions in self._subscriptions.items():
+            for sub in subscriptions:
+                if sub.netloc in broken_hosts:
+                    # XXX: Record a broken delivery
+                    continue
+                dialect = dialects[sub]
+                key = (dialect, data)
+                try:
+                    ext_data = serialized_data_by_dialect[key]
+                except KeyError:
+                    # TODO: What if externalizing depends on who is getting the data?
+                    # (Which I think it may; the current user sometimes comes into play)
+                    # Do we need to switch out the current user? What about the pyramid request?
+                    ext_data = serialized_data_by_dialect[key] = dialect.externalizeData(data)
+
+                serialized_data_by_sub.append((sub, dialect, ext_data))
+
+        # Now, unify the URLs. For each URL in a subscription, collect the
+        # distinct set of data to send. This is per-dialect.
+        all_data = {} # (url, dialect) -> ext_data
+        for subscription, dialect, ext_data in serialized_data_by_sub:
+            key = (subscription.to, dialect)
+            if key not in all_data:
+                all_data[key] = ext_data
+            else:
+                # TODO: This requires deterministic output from the seriaizer,
+                # such as sorting keys.
+                assert all_data[key] == ext_data
+
+        # XXX: Record pending deliveries for all these subscriptions.
+        # XXX: Because we're writing data here, maybe we need to happen earlier?
+        # Or maybe this needs to happen in a hook? Concerned about making it properly
+        # visible to ZODB connections.
+        self._voted_data = all_data
+
+    @foreign_transaction
+    def tpc_finish(self, transaction):
+        pass
+
+    @foreign_transaction
+    def tpc_abort(self, transaction):
+        pass
+
+    def abort(self, tranasction):
+        self.transaction = None
+        self._subscriptions = None
+
+    @foreign_transaction
+    def commit(self, transaction):
+        pass
+
+    def sortKey(self):
+        return 'nti.webhooks.datamanager.WebhookDataManager'

--- a/src/nti/webhooks/delivery_manager.py
+++ b/src/nti/webhooks/delivery_manager.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+Default implementation of the delivery manager.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from zope import interface
+
+
+from nti.webhooks.interfaces import IWebhookDeliveryManager
+from nti.webhooks.interfaces import IWebhookDeliveryManagerShipmentInfo
+
+@interface.implementer(IWebhookDeliveryManagerShipmentInfo)
+class ShipmentInfo(object):
+    pass
+
+@interface.implementer(IWebhookDeliveryManager)
+class DefaultDeliveryManager(object):
+
+
+    def createShipmentInfo(self, subscriptions_and_attempts):
+        return ShipmentInfo()
+
+    def acceptForDelivery(self, shipment_info):
+        assert isinstance(shipment_info, ShipmentInfo)

--- a/src/nti/webhooks/delivery_manager.py
+++ b/src/nti/webhooks/delivery_manager.py
@@ -34,7 +34,7 @@ class _TrivialShipmentInfo(ShipmentInfo):
             # XXX: Store the full response status, data (to some limit) and headers.
             # We don't want to pickle the Response object to avoid depending on internal
             # details, we need to extract it.
-            attempt.message = '%s %s' % (response.status_code, response.reason)
+            attempt.message = u'%s %s' % (response.status_code, response.reason)
 
 @interface.implementer(IWebhookDeliveryManager)
 class DefaultDeliveryManager(Contained):

--- a/src/nti/webhooks/delivery_manager.py
+++ b/src/nti/webhooks/delivery_manager.py
@@ -8,8 +8,9 @@ from __future__ import division
 from __future__ import print_function
 
 
-from zope import interface
+import requests
 
+from zope import interface
 
 from nti.webhooks.interfaces import IWebhookDeliveryManager
 from nti.webhooks.interfaces import IWebhookDeliveryManagerShipmentInfo
@@ -18,12 +19,32 @@ from nti.webhooks.interfaces import IWebhookDeliveryManagerShipmentInfo
 class ShipmentInfo(object):
     pass
 
+class _TrivialShipmentInfo(ShipmentInfo):
+
+    def __init__(self, subscriptions_and_attempts):
+        # This doesn't handle persistent objects.
+        self._sub_and_attempts = list(subscriptions_and_attempts)
+
+    def deliver(self):
+        for sub, attempt in self._sub_and_attempts:
+            response = requests.post(sub.to, data=attempt.payload_data)
+            attempt.status = 'successful' if response.ok else 'failed'
+            # XXX: Store the full response status, data (to some limit) and headers.
+            # We don't want to pickle the Response object to avoid depending on internal
+            # details, we need to extract it.
+            attempt.message = '%s %s' % (response.status_code, response.reason)
+
 @interface.implementer(IWebhookDeliveryManager)
 class DefaultDeliveryManager(object):
-
-
+    # TODO: Use concurrent.futures to send these using a threadpool.
     def createShipmentInfo(self, subscriptions_and_attempts):
-        return ShipmentInfo()
+        # TODO: Group by domain and re-use request sessions.
+        return _TrivialShipmentInfo(subscriptions_and_attempts)
 
     def acceptForDelivery(self, shipment_info):
         assert isinstance(shipment_info, ShipmentInfo)
+
+        shipment_info.deliver()
+
+    def waitForPendingDeliveries(self):
+        pass

--- a/src/nti/webhooks/delivery_manager.py
+++ b/src/nti/webhooks/delivery_manager.py
@@ -7,10 +7,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-
+from concurrent import futures
 import requests
 
 from zope import interface
+from zope.container.contained import Contained
+from zope.cachedescriptors.property import Lazy
 
 from nti.webhooks.interfaces import IWebhookDeliveryManager
 from nti.webhooks.interfaces import IWebhookDeliveryManagerShipmentInfo
@@ -35,16 +37,57 @@ class _TrivialShipmentInfo(ShipmentInfo):
             attempt.message = '%s %s' % (response.status_code, response.reason)
 
 @interface.implementer(IWebhookDeliveryManager)
-class DefaultDeliveryManager(object):
-    # TODO: Use concurrent.futures to send these using a threadpool.
+class DefaultDeliveryManager(Contained):
+
+    def __init__(self, name):
+        self.__name__ = name
+        self.__parent__ = None
+        self.__tasks = []
+
+    def __reduce__(self):
+        return self.__name__
+
+    @Lazy
+    def _pool(self):
+        # Delay creating a thread pool until used for monkey-patching
+        return futures.ThreadPoolExecutor(thread_name_prefix='WebhookDeliveryManager')
+
     def createShipmentInfo(self, subscriptions_and_attempts):
         # TODO: Group by domain and re-use request sessions.
         return _TrivialShipmentInfo(subscriptions_and_attempts)
 
     def acceptForDelivery(self, shipment_info):
         assert isinstance(shipment_info, ShipmentInfo)
+        future = self._pool.submit(shipment_info.deliver) # pylint:disable=no-member
+        # Thread safety: We're relying on the GIL here to make
+        # appending and removal atomic and possible across threads.
+        self.__tasks.append(future)
+        future.add_done_callback(self.__tasks.remove)
 
-        shipment_info.deliver()
+    def waitForPendingDeliveries(self, timeout=None):
+        # Thread safety: We're relying on the GIL to make copying the list
+        # of futures atomic. It's probably important to pass a new list here
+        # so that it doesn't mutate out from under the waiter as things finish.
+        # Note that this waits only for tasks that were already submitted.
+        futures.wait(list(self.__tasks), timeout=timeout)
 
-    def waitForPendingDeliveries(self):
-        pass
+    def _reset(self):
+        # Called for test cleanup.
+        pool = self.__dict__.pop('_pool', None)
+        self.__tasks = []
+        if pool is not None:
+            pool.shutdown()
+
+# Name string must match variable identifier for pickling
+global_delivery_manager = DefaultDeliveryManager('global_delivery_manager')
+
+@interface.implementer(IWebhookDeliveryManager)
+def getGlobalDeliveryManager():
+    return global_delivery_manager
+
+try:
+    from zope.testing.cleanup import addCleanUp # pylint:disable=ungrouped-imports
+except ImportError: # pragma: no cover
+    pass
+else:
+    addCleanUp(global_delivery_manager._reset) # pylint:disable=protected-access

--- a/src/nti/webhooks/destination_validator.py
+++ b/src/nti/webhooks/destination_validator.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Implementations of :class:`nti.webhooks.interfaces.IWebhookDestinationValidator`
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import socket
+try:
+    from urllib.parse import urlsplit
+except ImportError: # Py2
+    from urlparse import urlsplit
+
+from zope import interface
+
+from nti.webhooks import interfaces
+
+@interface.implementer(interfaces.IWebhookDestinationValidator)
+class DefaultDestinationValidator(object):
+
+    def validateTarget(self, target_url):
+        parsed_url = urlsplit(target_url)
+        if parsed_url.scheme != 'https':
+            raise ValueError("Refusing to deliver to insecure destination")
+
+        domain = parsed_url.netloc
+        # Look it up, raise an exception if not found.
+        # TODO: Caching.
+        socket.getaddrinfo(domain, 'https')

--- a/src/nti/webhooks/dialect.py
+++ b/src/nti/webhooks/dialect.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+Implementations of dialects.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from zope.interface import implementer
+
+from nti import externalization
+from nti.webhooks.interfaces import IWebhookDialect
+
+@implementer(IWebhookDialect)
+class DefaultWebhookDialect(object):
+
+    externalizer_name = u'webhook-delivery'
+
+    def __init__(self):
+        pass
+
+    def externalizeData(self, data):
+        ext_data = externalization.to_external_representation(data,
+                                                              name=self.externalizer_name)
+        return ext_data

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -22,6 +22,7 @@ from zope.componentvocabulary.vocabulary import UtilityNames
 from zope.principalregistry.metadirectives import TextId
 
 from zope.schema import Field
+from zope.schema import NativeString
 
 from nti.schema.field import Object
 from nti.schema.field import ValidText as Text
@@ -207,7 +208,9 @@ class IWebhookDeliveryAttempt(IContained, ILastModified):
         required=False,
     )
 
-    payload_data = Text(
+    payload_data = NativeString(
+        # XXX: Think this through. Should it always be bytes? Displaying
+        # in the web interface gets more complicated that way...
         title=u"The external data sent to the destination.",
         required=True,
     )

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+Interface definitions for ``nti.webhooks``.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from zope.interface import Interface
+
+# pylint:disable=inherit-non-class
+
+__all__ = [
+    'IWebhookDeliveryManager',
+]
+
+class IWebhookDeliveryManager(Interface):
+    """
+    Handles the delivery of messages.
+
+    This is usually a global utility registered by the
+    ZCML of this package.
+    """

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -8,11 +8,33 @@ from __future__ import division
 from __future__ import print_function
 
 from zope.interface import Interface
+from zope.interface.interfaces import IInterface
+from zope.interface.interfaces import IObjectEvent
+
+from zope.container.interfaces import IContainer
+from zope.container.constraints import contains
+from zope.container.constraints import containers
+
+from zope.componentvocabulary.vocabulary import UtilityNames
+
+from zope.principalregistry.metadirectives import TextId
+
+from zope.schema import Field
+
+from nti.schema.field import Object
+from nti.schema.field import ValidChoice as Choice
+
+from nti.webhooks._schema import ObjectEventInterface
+from nti.webhooks._schema import HTTPSURL
 
 # pylint:disable=inherit-non-class
 
 __all__ = [
     'IWebhookDeliveryManager',
+    'IWebhookPayload',
+    'IWebhookDialect',
+    'IWebhookSubscription',
+    'IWebhookSubscriptionManager',
 ]
 
 class IWebhookDeliveryManager(Interface):
@@ -22,3 +44,119 @@ class IWebhookDeliveryManager(Interface):
     This is usually a global utility registered by the
     ZCML of this package.
     """
+
+
+class IWebhookPayload(Interface):
+    """
+    Marker interface for objects that can automatically
+    become the payload of a webhook.
+
+    This interface is used as the default in a number of
+    places.
+
+    TODO: More docs as this evolves.
+    """
+
+class IWebhookDialect(Interface):
+    """
+    Quirks for sending webhooks to specific services.
+    """
+
+
+class IWebhookSubscription(Interface):
+    """
+    An individual subscription.
+
+    XXX: This is probably a container for the delivery items.
+    """
+    containers('IWebhookSubscriptionManager')
+
+    for_ = Field(
+        title=u"The type of object to attempt delivery for.",
+        description=u"""
+        When object events of type *when* are fired for instances
+        providing this interface, webhook delivery to *target* might be attempted.
+
+        The default is objects that implement :class:`~.IWebhookPayload`.
+
+        This is interpreted as for :func:`zope.component.registerAdapter` and
+        may name an interface or a type.
+        """,
+
+        default=IWebhookPayload,
+        required=True
+    )
+
+    when = Object(
+        schema=IInterface,
+        title=u'The type of event that should result in attempted deliveries.',
+        description=u"""
+        A type of ``IObjectEvent``, usually one defined in :mod:`zope.lifecycleevent.interfaces` such
+        as ``IObjectCreatedEvent``. The *object* field of this event must provide the
+        ``for_`` interface; it's the data from the *object* field of this event that
+        will be sent to the webhook.
+
+        If not specified, *all* object events involving the ``for_`` interface
+        will be sent.
+
+        This must be an interface.
+        """,
+        default=IObjectEvent,
+        required=True,
+        constraint=lambda value: value.isOrExtends(IObjectEvent)
+    )
+
+    to = HTTPSURL(
+        title=u"The complete destination URL to which the data should be sent",
+        description=u"""
+        This is an arbitrary HTTPS URL. Only HTTPS is supported for
+        delivery of webhooks.
+        """,
+        required=True,
+    )
+
+    owner_id = TextId(
+        title=u"The ID of the ``IPrincipal`` that owns this subscription.",
+        description=u"""
+        This will be validated at runtime when an event arrives. If
+        the current ``zope.security.interfaces.IAuthentication`` utility cannot find
+        a principal with the given ID, the delivery will be failed.
+
+        Leave unset to disable security checks.
+        """,
+        required=False,
+    )
+
+    permission = Choice(
+        title=u"The ID of the permission to check",
+        description=u"""
+        If given, and an *owner* is also specified, then only data that
+        has this permission for the *owner* will result in an attempted delivery.
+        If not given, but an *owner* is given, this will default to the standard
+        view permission ID, ``zope.View``.
+
+        If the permission ID cannot be found at runtime, the delivery will fail.
+        """,
+        required=False,
+        vocabulary="Permission Ids",
+    )
+
+    # TODO: Where does specification of the request method go?
+    # Dialect or subscription?
+    dialect_id = Choice(
+        title=u"The ID of the `IWebhookDialect` to use",
+        description=u"""
+        XXX Fill me in.
+        """,
+        required=False,
+        vocabulary=UtilityNames(IWebhookDialect),
+    )
+
+
+class IWebhookSubscriptionManager(IContainer):
+    """
+    A utility that manages subscriptions.
+
+    Also a registry for which subscriptions fire on what events.
+    """
+    contains(IWebhookSubscription)

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -11,7 +11,7 @@ from zope.interface import Interface
 from zope.interface.interfaces import IInterface
 from zope.interface.interfaces import IObjectEvent
 
-from zope.container.interfaces import IContainer
+from zope.container.interfaces import IContainerNamesContainer
 from zope.container.constraints import contains
 from zope.container.constraints import containers
 
@@ -24,10 +24,9 @@ from zope.schema import Field
 from nti.schema.field import Object
 from nti.schema.field import ValidChoice as Choice
 
-from nti.webhooks._schema import ObjectEventInterface
 from nti.webhooks._schema import HTTPSURL
 
-# pylint:disable=inherit-non-class
+# pylint:disable=inherit-non-class,no-self-argument
 
 __all__ = [
     'IWebhookDeliveryManager',
@@ -69,7 +68,7 @@ class IWebhookSubscription(Interface):
 
     XXX: This is probably a container for the delivery items.
     """
-    containers('IWebhookSubscriptionManager')
+    containers('.IWebhookSubscriptionManager')
 
     for_ = Field(
         title=u"The type of object to attempt delivery for.",
@@ -127,7 +126,7 @@ class IWebhookSubscription(Interface):
         required=False,
     )
 
-    permission = Choice(
+    permission_id = Choice(
         title=u"The ID of the permission to check",
         description=u"""
         If given, and an *owner* is also specified, then only data that
@@ -153,10 +152,16 @@ class IWebhookSubscription(Interface):
     )
 
 
-class IWebhookSubscriptionManager(IContainer):
+class IWebhookSubscriptionManager(IContainerNamesContainer):
     """
     A utility that manages subscriptions.
 
     Also a registry for which subscriptions fire on what events.
     """
     contains(IWebhookSubscription)
+
+    def addSubscription(subscription):
+        """
+        XXX: Document me.
+        :param subscription: A `IWebhookSubscription`.
+        """

--- a/src/nti/webhooks/meta.zcml
+++ b/src/nti/webhooks/meta.zcml
@@ -1,0 +1,15 @@
+<!-- -*- mode: nxml -*- -->
+<configure  xmlns="http://namespaces.zope.org/zope"
+            xmlns:i18n="http://namespaces.zope.org/i18n"
+            xmlns:zcml="http://namespaces.zope.org/zcml"
+            xmlns:meta="http://namespaces.zope.org/meta">
+
+    <meta:directives namespace="http://nextthought.com/ntp/webhooks">
+        <meta:directive
+            name="staticSubscription"
+            schema="nti.webhooks.zcml.IStaticSubscriptionDirective"
+            handler="nti.webhooks.zcml.static_subscription"
+            />
+    </meta:directives>
+
+</configure>

--- a/src/nti/webhooks/subscribers.py
+++ b/src/nti/webhooks/subscribers.py
@@ -12,10 +12,70 @@ from __future__ import print_function
 
 __all__ = ()
 
+import transaction
 from zope import component
+from zope.interface import providedBy
 
-from .interfaces import IWebhookDeliveryManager
 
-def on_webhook_event(data, event):
-    manager = component.getUtility(IWebhookDeliveryManager)
-    manager.temp(data, event)
+from nti.webhooks.interfaces import IWebhookSubscriptionManager
+from nti.webhooks.datamanager import WebhookDataManager
+
+def find_active_subscriptions_for(data, event):
+    """
+    Part of `dispatch_webhook_event`, broken out for testing.
+
+    Internal use only.
+    """
+    # TODO: What's the practical difference using ``getUtilitiesFor`` and manually walking
+    # through the tree using ``getNextUtility``? The first makes a single call to the adapter
+    # registry and uses its own ``.ro`` to walk up and find utilities. The second uses
+    # the ``__bases__`` of the site manager itself to walk up and find only the next utility.
+    subscriptions = []
+    provided = [providedBy(data), providedBy(event)]
+    last_sub_manager = None
+    for context in None, data:
+        # A context of None means to use the current site manager.
+        sub_managers = component.getUtilitiesFor(IWebhookSubscriptionManager, context)
+        for _name, sub_manager in sub_managers:
+            if sub_manager is last_sub_manager:
+                # De-dup.
+                continue
+            last_sub_manager = sub_manager
+            local_subscriptions = sub_manager.registry.adapters.subscriptions(provided, None)
+            subscriptions.extend(local_subscriptions)
+    return subscriptions
+
+def dispatch_webhook_event(data, event):
+    """
+    A subcriber installed globally to dispatch events to webhook
+    subscriptions.
+
+    This is registered globally for ``(*, IObjectEvent)`` (TODO: It
+    would be nice to make that more specific. Maybe we want to require
+    objects to implement the ``IWebhookPayload`` interface?.)
+
+    This function:
+
+    - Queries for all active subscriptions in the ``IWebhookSubscriptionManager``
+      instances in the current site hierarchy;
+    - And queries for all active subscriptions in the ``IWebhookSubscriptionManager``
+      instances in the context of the *data*, which may be separate.
+    - Determines if any of those actually apply to the *data*, and if so,
+      joins the transaction to prepare for sending them.
+    """
+    subscriptions = find_active_subscriptions_for(data, event)
+    subscriptions = [sub for sub in subscriptions if sub.isApplicable(data)]
+    if subscriptions:
+        # TODO: Choosing which datamanager resource to use might
+        # be a good extension point.
+        tx_man = transaction.manager
+        tx = tx_man.get() # If not begun, this is an error.
+
+        try:
+            data_man = tx.data(dispatch_webhook_event)
+        except KeyError:
+            data_man = WebhookDataManager(tx_man, data, event, subscriptions)
+            tx.set_data(dispatch_webhook_event, data_man)
+            tx.join(data_man)
+        else:
+            data_man.add_subscriptions(data, event, subscriptions)

--- a/src/nti/webhooks/subscribers.py
+++ b/src/nti/webhooks/subscribers.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+Event subscribers.
+
+This is an internal implementation module
+and contains no public code.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__all__ = ()
+
+from zope import component
+
+from .interfaces import IWebhookDeliveryManager
+
+def on_webhook_event(data, event):
+    manager = component.getUtility(IWebhookDeliveryManager)
+    manager.temp(data, event)

--- a/src/nti/webhooks/subscriptions.py
+++ b/src/nti/webhooks/subscriptions.py
@@ -93,7 +93,12 @@ class Subscription(SchemaConfigured, _CheckObjectOnSetBTreeContainer):
             validator.validateTarget(self.to)
         except Exception as ex: # pylint:disable=broad-except
             attempt.status = 'failed'
-            attempt.message = str(ex)
+            # The exception value can vary; it's not intended to be presented to end
+            # users as-is
+            # XXX: For internal verification, we need some place to store it.
+            attempt.message = (
+                u'Verification of the destination URL failed. Please check the domain.'
+            )
 
         return attempt
 

--- a/src/nti/webhooks/subscriptions.py
+++ b/src/nti/webhooks/subscriptions.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+Subscription implementations.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from zope.interface import implementer
+from zope.component.globalregistry import BaseGlobalComponents
+
+from zope.container.interfaces import INameChooser
+from zope.container.btree import BTreeContainer
+from zope.container.constraints import checkObject
+
+from nti.externalization.representation import WithRepr
+from nti.schema.fieldproperty import createDirectFieldProperties
+from nti.schema.schema import SchemaConfigured
+from nti.webhooks.interfaces import IWebhookSubscription
+from nti.webhooks.interfaces import IWebhookSubscriptionManager
+
+from persistent import Persistent
+
+@WithRepr
+@implementer(IWebhookSubscription)
+class Subscription(SchemaConfigured):
+    """
+    Default, non-persistent implementation of `IWebhookSubscription`.
+    """
+    createDirectFieldProperties(IWebhookSubscription)
+
+
+class PersistentSubscription(Subscription, Persistent):
+    """
+    Persistent implementation of `IWebhookSubscription`
+    """
+
+class _CheckObjectOnSetBTreeContainer(BTreeContainer):
+    # XXX: Taken from nti.containers. Should publish that package.
+
+    def _setitemf(self, key, value):
+        checkObject(self, key, value)
+        super(_CheckObjectOnSetBTreeContainer, self)._setitemf(key, value)
+
+
+class GlobalSubscriptionComponents(BaseGlobalComponents):
+    """
+    Exists to be pickled by name.
+    """
+
+global_subscription_registry = GlobalSubscriptionComponents('global_subscription_registry')
+
+@implementer(IWebhookSubscriptionManager)
+class GlobalWebhookSubscriptionManager(_CheckObjectOnSetBTreeContainer):
+
+    def __init__(self, name):
+        super(GlobalWebhookSubscriptionManager, self).__init__()
+        self.registry = global_subscription_registry
+        self.__name__ = name
+
+    def __reduce__(self):
+        # The global manager is pickled as a global object.
+        return self.__name__
+
+    def addSubscription(self, subscription):
+        name_chooser = INameChooser(self)
+        name = name_chooser.chooseName('', subscription) # too-many-function-args,assignment-from-no-return
+        self[name] = subscription
+
+        self.registry.registerHandler(subscription, (subscription.for_, subscription.when))
+
+# The name string must match the variable name to pickle correctly
+global_subscription_manager = GlobalWebhookSubscriptionManager('global_subscription_manager')
+
+def getGlobalSubscriptionManager():
+    return global_subscription_manager
+
+def resetGlobals():
+    global_subscription_manager.__init__('global_subscription_manager')
+    global_subscription_registry.__init__('global_subscription_registry')
+
+try:
+    from zope.testing.cleanup import addCleanUp # pylint:disable=ungrouped-imports
+except ImportError: # pragma: no cover
+    pass
+else:
+    addCleanUp(resetGlobals)
+    del addCleanUp

--- a/src/nti/webhooks/subscriptions.py
+++ b/src/nti/webhooks/subscriptions.py
@@ -7,12 +7,19 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+try:
+    from urllib.parse import urlsplit
+except ImportError: # Py2
+    from urlparse import urlsplit
+
+
 from zope.interface import implementer
 from zope.component.globalregistry import BaseGlobalComponents
 
 from zope.container.interfaces import INameChooser
 from zope.container.btree import BTreeContainer
 from zope.container.constraints import checkObject
+from zope.cachedescriptors.property import CachedProperty
 
 from nti.externalization.representation import WithRepr
 from nti.schema.fieldproperty import createDirectFieldProperties
@@ -22,19 +29,6 @@ from nti.webhooks.interfaces import IWebhookSubscriptionManager
 
 from persistent import Persistent
 
-@WithRepr
-@implementer(IWebhookSubscription)
-class Subscription(SchemaConfigured):
-    """
-    Default, non-persistent implementation of `IWebhookSubscription`.
-    """
-    createDirectFieldProperties(IWebhookSubscription)
-
-
-class PersistentSubscription(Subscription, Persistent):
-    """
-    Persistent implementation of `IWebhookSubscription`
-    """
 
 class _CheckObjectOnSetBTreeContainer(BTreeContainer):
     # XXX: Taken from nti.containers. Should publish that package.
@@ -42,6 +36,51 @@ class _CheckObjectOnSetBTreeContainer(BTreeContainer):
     def _setitemf(self, key, value):
         checkObject(self, key, value)
         super(_CheckObjectOnSetBTreeContainer, self)._setitemf(key, value)
+
+
+@WithRepr
+@implementer(IWebhookSubscription)
+class Subscription(SchemaConfigured, _CheckObjectOnSetBTreeContainer):
+    """
+    Default, non-persistent implementation of `IWebhookSubscription`.
+    """
+    for_ = permission_id = owner_id = None
+    to = u''
+    createDirectFieldProperties(IWebhookSubscription)
+
+    def __init__(self, **kwargs):
+        SchemaConfigured.__init__(self, **kwargs)
+        _CheckObjectOnSetBTreeContainer.__init__(self)
+
+    def isApplicable(self, data):
+        if hasattr(self.for_, 'providedBy'):
+            if not self.for_.providedBy(data):
+                return False
+        else:
+            if not isinstance(data, self.for_): # pylint:disable=isinstance-second-argument-not-valid-type
+                return False
+
+        if not self.permission_id or not self.owner_id:
+            return True
+
+        # TODO: Check the principal and the permission. Find the permission
+        # by name in the registry, find the principal_id by name in the
+        # registry, use the security policy to check access.
+        # TODO: We probably need to do the principal lookup in the context of the data, just in case
+        # there are local principal registries.
+        return False
+
+    @CachedProperty('to')
+    def netloc(self):
+        """
+        The host name of the ``to`` address.
+        """
+        return urlsplit(self.to).netloc
+
+class PersistentSubscription(Subscription, Persistent):
+    """
+    Persistent implementation of `IWebhookSubscription`
+    """
 
 
 class GlobalSubscriptionComponents(BaseGlobalComponents):
@@ -68,7 +107,8 @@ class GlobalWebhookSubscriptionManager(_CheckObjectOnSetBTreeContainer):
         name = name_chooser.chooseName('', subscription) # too-many-function-args,assignment-from-no-return
         self[name] = subscription
 
-        self.registry.registerHandler(subscription, (subscription.for_, subscription.when))
+        self.registry.registerHandler(subscription, (subscription.for_, subscription.when),
+                                      event=False)
 
 # The name string must match the variable name to pickle correctly
 global_subscription_manager = GlobalWebhookSubscriptionManager('global_subscription_manager')

--- a/src/nti/webhooks/tests/__init__.py
+++ b/src/nti/webhooks/tests/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""
+The test package.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function

--- a/src/nti/webhooks/tests/test_subscriptions.py
+++ b/src/nti/webhooks/tests/test_subscriptions.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for subscriptions.py
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+import unittest
+from hamcrest import assert_that
+from hamcrest import is_
+from hamcrest import same_instance
+from hamcrest import has_properties
+
+from nti.webhooks import subscriptions
+
+class TestGlobalWebhookSubscriptionManager(unittest.TestCase):
+
+    def test_pickle(self):
+        import pickle
+
+        gsm = subscriptions.global_subscription_manager
+
+        gsm_2 = pickle.loads(pickle.dumps(gsm))
+
+        assert_that(gsm_2, is_(same_instance(gsm)))
+        assert_that(gsm_2, has_properties(registry=same_instance(gsm.registry)))
+
+        assert_that(gsm_2.registry,
+                    has_properties(adapters=same_instance(gsm.registry.adapters),
+                                   utilities=same_instance(gsm.registry.utilities)))

--- a/src/nti/webhooks/zcml.py
+++ b/src/nti/webhooks/zcml.py
@@ -16,10 +16,14 @@ from zope.schema.interfaces import InvalidURI
 from zope.interface import Interface
 from zope.interface.interfaces import IObjectEvent
 
+from zope.component.zcml import subscriber
+
 from zope.security.zcml import Permission
 from zope.principalregistry.metadirectives import TextId
 
 from nti.schema.field import ValidURI
+
+from .subscribers import on_webhook_event
 
 # pylint:disable=inherit-non-class
 
@@ -160,4 +164,5 @@ def static_subscription(context, **kwargs):
     if kwargs: # pragma: no cover
         raise TypeError
 
-    # print(dict(locals()))
+    subscriber(context, for_=(for_, when), handler=on_webhook_event,
+               trusted=True, locate=True)

--- a/src/nti/webhooks/zcml.py
+++ b/src/nti/webhooks/zcml.py
@@ -8,69 +8,18 @@ from __future__ import division
 from __future__ import print_function
 
 from zope.configuration.fields import GlobalObject
-from zope.configuration.fields import GlobalInterface
-from zope.schema import InterfaceField
-from zope.schema.interfaces import NotAnInterface
-from zope.schema.interfaces import InvalidURI
 
 from zope.interface import Interface
-from zope.interface.interfaces import IObjectEvent
 
 from zope.component.zcml import subscriber
 
 from zope.security.zcml import Permission
-from zope.principalregistry.metadirectives import TextId
 
-from nti.schema.field import ValidURI
-
-from .subscribers import on_webhook_event
+from nti.webhooks.subscribers import on_webhook_event
+from nti.webhooks.interfaces import IWebhookSubscription
+from nti.webhooks._schema import ObjectEventInterface
 
 # pylint:disable=inherit-non-class
-
-class _NotAnObjectEvent(NotAnInterface):
-    """
-    Raised when the interface is not for an IObjectEvent.
-    """
-
-class _ObjectEventField(InterfaceField):
-    """
-    A field that requires an interface that is a kind of ``IObjectEvent``.
-    """
-    def _validate(self, value):
-        super(_ObjectEventField, self)._validate(value)
-        if not value.isOrExtends(IObjectEvent):
-            raise _NotAnObjectEvent(
-                value,
-                self.__name__
-            ).with_field_and_value(self, value)
-
-class _ObjectEventInterface(GlobalInterface):
-    """
-    A configuration field that looks up a named ``IObjectEvent``
-    interface.
-    """
-    def __init__(self, **kwargs):
-        super(_ObjectEventInterface, self).__init__(**kwargs)
-        self.value_type = _ObjectEventField()
-
-
-class _HTTPSURL(ValidURI):
-    """
-    A URI that's HTTPS only.
-
-    As opposed to nti.schema.field.HTTPURL, this:
-
-    - allows for a port
-    - allows for inline authentication (``https://user:pass@host/path/``)
-    - Requires the URL scheme to be specified, and requires it to be HTTPS.
-
-    TODO: Move all those capabilities to nti.schema.
-    """
-
-    def _validate(self, value):
-        super(_HTTPSURL, self)._validate(value)
-        if not value.lower().startswith('https://'):
-            raise InvalidURI(value).with_field_and_value(self, value)
 
 class IStaticSubscriptionDirective(Interface):
     """
@@ -84,63 +33,24 @@ class IStaticSubscriptionDirective(Interface):
     """
 
     for_ = GlobalObject(
-        title=u"The type of object to attempt delivery for.",
-        description=u"""
-        When object events of type *when* are fired for instances
-        providing this interface, webhook delivery to *target* might be attempted.
-
-        The default is for *all* objects to fire webhooks. That's probably not
-        what you want and you should specify a particular interface.
-
-        This is interpreted as for :func:`zope.component.registerAdapter` and
-        may name an interface or a type.
-        """,
-        default=Interface,
+        title=IWebhookSubscription['for_'].title,
+        description=IWebhookSubscription['for_'].description,
+        default=IWebhookSubscription['for_'].default,
         required=False,
     )
 
-    when = _ObjectEventInterface(
-        title=u'The type of event that should result in attempted deliveries.',
-        description=u"""
-        A type of ``IObjectEvent``, usually one defined in :mod:`zope.lifecycleevent.interfaces` such
-        as ``IObjectCreatedEvent``. The *object* field of this event must provide the
-        ``for_`` interface; it's the data from the *object* field of this event that
-        will be sent to the webhook.
-
-        If not specified, *all* object events involving the ``for_`` interface
-        will be sent.
-
-        This must be an interface.
-        """,
-        default=IObjectEvent,
+    when = ObjectEventInterface(
+        title=IWebhookSubscription['when'].title,
+        description=IWebhookSubscription['when'].description,
+        default=IWebhookSubscription['when'].default,
         required=False,
     )
 
-    to = _HTTPSURL(
-        title=u"The complete destination URL to which the data should be sent",
-        description=u"""
-        This is an arbitrary HTTPS URL. Only HTTPS is supported for
-        delivery of webhooks.
-        """,
-        required=True,
-    )
+    to = IWebhookSubscription['to'].bind(None)
 
-    # TODO: Where does specification of the request method go?
-    # Dialect or subscription?
-    # TODO: Fill in dialect. Should refer to named utilities.
-    #dialect = XXX
+    dialect = IWebhookSubscription['dialect_id'].bind(None)
 
-    owner = TextId(
-        title=u"The ID of the ``IPrincipal`` that owns this subscription.",
-        description=u"""
-        This will be validated at runtime when an event arrives. If
-        the current ``zope.security.interfaces.IAuthentication`` utility cannot find
-        a principal with the given ID, the delivery will be failed.
-
-        Leave unset to disable security checks.
-        """,
-        required=False,
-    )
+    owner = IWebhookSubscription['owner_id'].bind(None)
 
     permission = Permission(
         title=u"The permission to check",

--- a/src/nti/webhooks/zcml.py
+++ b/src/nti/webhooks/zcml.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+Support for configuring webhook delivery using ZCML.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from zope.configuration.fields import GlobalInterface
+from zope.schema import InterfaceField
+from zope.schema.interfaces import NotAnInterface
+from zope.schema.interfaces import InvalidURI
+
+from zope.interface import Interface
+from zope.interface.interfaces import IObjectEvent
+
+from zope.security.zcml import Permission
+from zope.principalregistry.metadirectives import TextId
+
+from nti.schema.field import ValidURI
+
+# pylint:disable=inherit-non-class
+
+class _NotAnObjectEvent(NotAnInterface):
+    """
+    Raised when the interface is not for an IObjectEvent.
+    """
+
+class _ObjectEventField(InterfaceField):
+    """
+    A field that requires an interface that is a kind of ``IObjectEvent``.
+    """
+    def _validate(self, value):
+        super(_ObjectEventField, self)._validate(value)
+        if not value.isOrExtends(IObjectEvent):
+            raise _NotAnObjectEvent(
+                value,
+                self.__name__
+            ).with_field_and_value(self, value)
+
+class _ObjectEventInterface(GlobalInterface):
+    """
+    A configuration field that looks up a named ``IObjectEvent``
+    interface.
+    """
+    def __init__(self, **kwargs):
+        super(_ObjectEventInterface, self).__init__(**kwargs)
+        self.value_type = _ObjectEventField()
+
+
+class _HTTPSURL(ValidURI):
+    """
+    A URI that's HTTPS only.
+
+    As opposed to nti.schema.field.HTTPURL, this:
+
+    - allows for a port
+    - allows for inline authentication (``https://user:pass@host/path/``)
+    - Requires the URL scheme to be specified, and requires it to be HTTPS.
+
+    TODO: Move all those capabilities to nti.schema.
+    """
+
+    def _validate(self, value):
+        super(_HTTPSURL, self)._validate(value)
+        if not value.lower.startswith('https://'):
+            raise InvalidURI(value).with_field_and_value(self, value)
+
+class IStaticSubscriptionDirective(Interface):
+    """
+    Define a static subscription.
+
+    Static subscriptions are not persistent and live only in the
+    memory of individual processes. Thus, failed deliveries cannot be
+    re-attempted after process shutdown. And of course the delivery history
+    is also transient and local to a process.
+
+    """
+
+    for_ = GlobalInterface(
+        title=u"The type of object to attempt delivery for.",
+        description=u"""
+        When object events of type *when* are fired for instances
+        having this interface, webhook delivery to *target* might be attempted.
+        """
+    )
+
+    when = _ObjectEventInterface(
+        title=u'The type of event that should result in attempted deliveries.',
+        description=u"""
+        A type of ``IObjectEvent``, usually one defined in :mod:`zope.lifecycleevent.interfaces` such
+        as ``IObjectCreatedEvent``. The *object* field of this event must provide the
+        ``for_`` interface; it's the data from the *object* field of this event that
+        will be sent to the webhook.
+
+        If not specified, *all* object events involving the ``for_`` interface
+        will be sent.
+        """,
+        default=IObjectEvent,
+        required=False,
+    )
+
+    to = _HTTPSURL(
+        title=u"The complete destination URL to which the data should be sent",
+        description=u"""
+        This is an arbitrary HTTPS URL. Only HTTPS is supported for
+        delivery of webhooks.
+        """
+    )
+
+    # TODO: Where does specification of the request method go?
+    # Dialect or subscription?
+    # TODO: Fill in dialect. Should refer to named utilities.
+    #dialect = XXX
+
+    owner = TextId(
+        title=u"The ID of the ``IPrincipal`` that owns this subscription.",
+        description=u"""
+        This will be validated at runtime when an event arrives. If
+        the current ``zope.security.interfaces.IAuthentication`` utility cannot find
+        a principal with the given ID, the delivery will be failed.
+
+        Leave unset to disable security checks.
+        """
+    )
+
+    permission = Permission(
+        title=u"The permission to check",
+        description=u"""
+        If given, and an *owner* is also specified, then only data that
+        has this permission for the *owner* will result in an attempted delivery.
+        If not given, but an *owner* is given, this will default to the standard
+        view permission ID, ``zope.View``.
+        """,
+        required=False
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ commands =
     coverage run -p -m zope.testrunner --test-path=src  --auto-color --auto-progress [] # substitute with tox positional args
 setenv =
     PYTHONHASHSEED=1042466059
-    ZOPE_INTERFACE_STRICT_IRO=1
+    # Not yet. https://github.com/NextThought/nti.externalization/pull/108
+    # ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:coverage]
 # The -i/--ignore arg may be necessary, I'm not sure.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,py27,py36,py37,py38,pypy3,coverage,docs
+envlist = pypy,py27,py36,py37,py38,pypy3,coverage,docs,docs2
 
 [testenv]
 # JAM: The comment and setting are cargo-culted from zope.interface.
@@ -31,4 +31,9 @@ parallel_show_output = true
 extras = docs
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
-    sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/html
+    sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctests
+
+[testenv:docs2]
+extras = docs
+commands =
+    sphinx-build -b doctest -d docs/_build/doctrees2 docs docs/_build/doctests2

--- a/tox.ini
+++ b/tox.ini
@@ -35,5 +35,6 @@ commands =
 
 [testenv:docs2]
 extras = docs
+basepython = python2.7
 commands =
     sphinx-build -b doctest -d docs/_build/doctrees2 docs docs/_build/doctests2

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ commands =
     coverage run -p -m zope.testrunner --test-path=src  --auto-color --auto-progress [] # substitute with tox positional args
 setenv =
     PYTHONHASHSEED=1042466059
-    # Not yet. https://github.com/NextThought/nti.externalization/pull/108
-    # ZOPE_INTERFACE_STRICT_IRO=1
+    ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:coverage]
 # The -i/--ignore arg may be necessary, I'm not sure.

--- a/tox.ini
+++ b/tox.ini
@@ -31,3 +31,4 @@ parallel_show_output = true
 extras = docs
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
+    sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/html


### PR DESCRIPTION
This implements:

- Basic delivery (no retries or anything of that nature; work needed there still, as is work around re-using HTTPS sessions)
- Basic attempt storage <del>(defining exactly what to store for an attempt still TODO)</del>
- Integrates permission checking

This does not implement:

- Anything persistent. It's purely in-memory only. 
- A well-defined API for anything except ZCML uses. Dynamic registration will need that (and persistence).

Both of those things were considered as this was in progress and as such should come relatively quickly. 

The docs `static.rst` and `security.rst`, in that order, should give a basic overview of the design direction, fleshed out by `interfaces.py` .

