### PR TITLE
Initial implementation of persistent subscriptions and deliveries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ not limited to:
   subscribes to "new user created" events at the global (root, base or
   "/") level, and a department head subscribes to "new user created"
   for their department ("/NOAA"), while a local office manager
-  subscribes to events for their office ("/NOAA/NWS/OKC"), then
+  subscribes to events for their office ("/NOAA/NWS/OUN"), then
   creating a new user in the OKC office may send three deliveries, one
   to the manager, one to the secretary, and one to the president.
 

--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -1,0 +1,5 @@
+==================
+ nti.webhooks.api
+==================
+
+.. automodule:: nti.webhooks.api

--- a/docs/api/delivery.rst
+++ b/docs/api/delivery.rst
@@ -1,0 +1,5 @@
+===============================
+ nti.webhooks.delivery_manager
+===============================
+
+.. automodule:: nti.webhooks.delivery_manager

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -5,4 +5,7 @@
 .. toctree::
 
    interfaces
+   api
    dialect
+   subscriptions
+   subscribers

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -7,5 +7,7 @@
    interfaces
    api
    dialect
+   delivery
    subscriptions
    subscribers
+   testing

--- a/docs/api/subscribers.rst
+++ b/docs/api/subscribers.rst
@@ -1,0 +1,5 @@
+==========================
+ nti.webhooks.subscribers
+==========================
+
+.. automodule:: nti.webhooks.subscribers

--- a/docs/api/subscriptions.rst
+++ b/docs/api/subscriptions.rst
@@ -1,0 +1,5 @@
+============================
+ nti.webhooks.subscriptions
+============================
+
+.. automodule:: nti.webhooks.subscriptions

--- a/docs/api/testing.rst
+++ b/docs/api/testing.rst
@@ -1,0 +1,5 @@
+======================
+ nti.webhooks.testing
+======================
+
+.. automodule:: nti.webhooks.testing

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -360,12 +360,14 @@ intersphinx_mapping = {
     'https://docs.python.org/': None,
     'https://requests.readthedocs.io/en/master/': None,
     'https://zodb-docs.readthedocs.io/en/latest/': None,
+    'https://persistent.readthedocs.io/en/latest/': None,
 
     'https://zopeauthentication.readthedocs.io/en/latest/': None,
     'https://zopecomponent.readthedocs.io/en/latest/': None,
     'https://zopecontainer.readthedocs.io/en/latest/': None,
     'https://zopeinterface.readthedocs.io/en/latest/': None,
     'https://zopelifecycleevent.readthedocs.io/en/latest/': None,
+    'https://zopelocation.readthedocs.io/en/latest/': None,
     'https://zopeprincipalregistry.readthedocs.io/en/latest/': None,
     'https://zopesecurity.readthedocs.io/en/latest/': None,
     'https://zopesite.readthedocs.io/en/latest/': None,
@@ -373,6 +375,7 @@ intersphinx_mapping = {
 
     'https://ntitesting.readthedocs.io/en/latest/': None,
     'https://ntischema.readthedocs.io/en/latest/': None,
+    'https://ntisite.readthedocs.io/en/latest/': None,
 }
 
 extlinks = {'issue': ('https://github.com/NextThought/nti.webhooks/issues/%s',

--- a/docs/dynamic.rst
+++ b/docs/dynamic.rst
@@ -4,4 +4,214 @@
 
 In addition to static webhook subscriptions defined in ZCML, this
 package supports dynamic webhook subscriptions created, activated,
-inactivated, and removed through code at runtime.
+inactivated, and removed through code at runtime. Such subscriptions,
+and their delivery history, are typically :class:`persistent
+<persistent.Persistent>` in the ZODB sense of the word.
+
+Subscriptions are managed via an implementation of
+:class:`nti.webhooks.interfaces.IWebhookSubscriptionManager`. We've
+already seen (in :doc:`static`) how there is a global, non-persistent
+subscription manager installed by default. This document explores
+issues around persistent, local subscription managers.
+
+Goals
+=====
+
+Persistent subscription managers, and their subscriptions and in turn
+delivery histories, should:
+
+- Have complete paths, as defined by
+  :meth:`zope.location.interfaces.ILocationInfo.getPath` or
+  :meth:`zope.traversing.interfaces.ITraversalAPI.getPath`.
+- Be fully traversable, as defined by
+  :meth:`zope.traversing.interfaces.ITraversalAPI.traverseName`.
+
+This second requirement is met by having the subscription manager be a
+:class:`zope.container.interfaces.IContainer` of
+``IWebhookSubscription`` objects, which in turn are containers
+of ``IWebhookDeliveryAttempt`` objects.
+
+The first requirement is somewhat harder. This package offers a
+high-level API to help with it, integrated with :mod:`nti.site`. In
+this API, persistent webhook subscription managers are stored in the
+site manager using :func:`nti.site.localutility.install_utility` with
+a name in the :class:`etc <zope.traversing.namespace.etc>` namespace.
+
+.. doctest::
+   :hide:
+
+   >>> from zope.configuration import xmlconfig
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="nti.webhooks" />
+   ...   <include package="nti.site" />
+   ...   <include package="zope.traversing" />
+   ... </configure>
+   ... """)
+   >>> from zope.component.hooks import setHooks
+   >>> setHooks()
+   >>> import nti.webhooks.testing
+   >>> __name__ = 'nti.webhooks.testing'
+
+
+Setup
+=====
+
+To begin, we will provide a persistent site hierarchy with traversable
+paths. Following the example from the main documentation, we'll create
+a department named "NWS" and office named "OUN", plus some people
+in each one. The department and office will be sites, with a site manager.
+
+First define the classes.
+
+.. doctest::
+
+   >>> from persistent import Persistent
+   >>> from zope.container.contained import Contained
+   >>> from zope.site.folder import Folder
+   >>> from zope.site import LocalSiteManager
+   >>> class Employees(Folder):
+   ...    def __init__(self):
+   ...        Folder.__init__(self)
+   ...        self['employees'] = Folder()
+   ...        self.setSiteManager(LocalSiteManager(self))
+   >>> class Department(Employees):
+   ...     pass
+   >>> class Office(Employees):
+   ...     pass
+   >>> class Employee(Contained, Persistent):
+   ...    pass
+
+.. doctest::
+   :hide:
+
+   >>> nti.webhooks.testing.Department = Department
+   >>> nti.webhooks.testing.Office = Office
+   >>> nti.webhooks.testing.Employee = Employee
+
+Now we'll create a database and store our hierarchy.
+
+.. doctest::
+
+   >>> import transaction
+   >>> from ZODB import DB
+   >>> from ZODB.DemoStorage import DemoStorage
+   >>> from nti.site.hostpolicy import install_main_application_and_sites
+   >>> from nti.site.testing import print_tree
+   >>> db = DB(DemoStorage())
+   >>> _ = transaction.begin()
+   >>> conn = db.open()
+   >>> root_folder, main_folder = install_main_application_and_sites(
+   ...        conn,
+   ...        root_alias=None, main_name='NOAA', main_alias=None)
+   >>> department = main_folder['NWS'] = Department()
+   >>> office = department['OUN'] = Office()
+   >>> department_bob = department['employees']['Bob'] = Employee()
+   >>> office_bob = office['employees']['Bob'] = Employee()
+   >>> print_tree(root_folder)
+        <ISite,IRootFolder>: <zope.site.folder.Folder object ...>
+            <ISite,IMainApplicationFolder>: NOAA ...
+                ++etc++hostsites ...
+                <ISite>: NWS ...
+                    <ISite>: OUN ...
+                        employees ...
+                            Bob ...
+                            ...
+                    employees ...
+                        Bob ...
+                            ...
+   >>> from zope.traversing import api as ztapi
+   >>> print(ztapi.getPath(office_bob))
+   /NOAA/NWS/OUN/employees/Bob
+   >>> transaction.commit()
+
+High-level API
+==============
+
+The high-level API lets us create subscriptions based on a resource,
+frequently one we've traversed to.
+
+.. autofunction:: nti.webhooks.api.subscribe_to_resource
+   :noindex:
+
+.. doctest::
+
+   >>> from nti.webhooks.api import subscribe_to_resource
+   >>> _ = transaction.begin()
+   >>> subscription = subscribe_to_resource(office_bob, 'https://example.com/some/path')
+   >>> subscription
+   <...PersistentSubscription at 0x... to='https://example.com/some/path' for=nti.webhooks.testing.Employee when=IObjectEvent>
+   >>> transaction.commit()
+
+By looking at the path, we can see that a subscription manager
+containing the subscription was created at the closest enclosing site
+manager. We can also traverse this path to get back to the subscription, and its
+manager:
+
+.. doctest::
+
+   >>> path = ztapi.getPath(subscription)
+   >>> print(path)
+   /NOAA/NWS/OUN/++etc++site/WebhookSubscriptionManager/PersistentSubscription
+   >>> ztapi.traverse(root_folder, path) is subscription
+   True
+   >>> ztapi.traverse(root_folder, '/NOAA/NWS/OUN/++etc++site/WebhookSubscriptionManager')
+   <....PersistentWebhookSubscriptionManager object at 0x...>
+
+Even though the office that contains this subscription is not the current site,
+we can still find this subscription and confirm that it is active.
+
+.. doctest::
+
+   >>> from zope.component import getSiteManager
+   >>> getSiteManager() is office.getSiteManager()
+   False
+   >>> from nti.webhooks.subscribers import find_active_subscriptions_for
+   >>> from zope.lifecycleevent import ObjectModifiedEvent
+   >>> event = ObjectModifiedEvent(office_bob)
+   >>> len(find_active_subscriptions_for(event.object, event))
+   1
+   >>> find_active_subscriptions_for(event.object, event)[0] is subscription
+   True
+
+A static subscription registered globally is also found:
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="zope.component" />
+   ...   <include package="zope.container" />
+   ...   <include package="nti.webhooks" />
+   ...   <webhooks:staticSubscription
+   ...             to="https://this_domain_does_not_exist"
+   ...             for="nti.webhooks.testing.Employee"
+   ...             when="zope.lifecycleevent.interfaces.IObjectModifiedEvent" />
+   ... </configure>
+   ... """)
+   >>> event = ObjectModifiedEvent(office_bob)
+   >>> subscriptions = find_active_subscriptions_for(event.object, event)
+   >>> len(subscriptions)
+   2
+   >>> subscriptions
+   [<...Subscription at 0x... to='https://this_domain_does_not_exist' for=Employee when=IObjectModifiedEvent>, <...PersistentSubscription at 0x... to='https://example.com/some/path' ... when=IObjectEvent>]
+
+TODO
+====
+
+- Removing subscriptions when principals are removed.
+- Add test to add new subscription when manager already exists.
+- Add subscription at higher level and find it too.
+
+
+.. testcleanup::
+
+   #using_mocks.finish()
+   from zope.testing import cleanup
+   cleanup.cleanUp()

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'zope.componentvocabulary',
         'zope.vocabularyregistry',
         'zope.site',
+        'nti.site',
         'nti.externalization >= 2.0.0', # Consistent interface resolution order
         'nti.schema',
         'setuptools',

--- a/src/nti/webhooks/api.py
+++ b/src/nti/webhooks/api.py
@@ -38,6 +38,9 @@ def subscribe_to_resource(resource, to, for_=None,
        interfaces.
     """
     if for_ is None:
+        # XXX: Probably want to direct this through an adapter
+        # so that it can easily be customized. Probably by default we'd
+        # get way too specific an interface.
         for_ = providedBy(resource)
 
     site_manager = getSiteManager(resource)

--- a/src/nti/webhooks/api.py
+++ b/src/nti/webhooks/api.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+API functions.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from zope.interface import providedBy
+from zope.component import getSiteManager
+from zope.container.interfaces import IContainer
+
+from nti.webhooks.interfaces import IWebhookSubscription
+from nti.webhooks.interfaces import IWebhookSubscriptionManager
+from nti.webhooks.subscriptions import PersistentWebhookSubscriptionManager
+
+def subscribe_to_resource(resource, to, for_=None,
+                          when=IWebhookSubscription['when'].default,
+                          dialect_id=IWebhookSubscription['dialect_id'].default,
+                          owner_id=None,
+                          permission_id=IWebhookSubscription['permission_id'].default):
+    """
+    Produce and return a persistent ``IWebhookSubscription`` based on the *resource*.
+
+    Only the *resource* and *to* arguments are mandatory. The other arguments are
+    optional, and are the same as the attributes in that interface.
+
+    :param resource: The resource to subscribe to. Passing a resource does two things.
+       First, the resources is used to find the closest enclosing ``ISite``
+       that is persistent. A ``IWebhookSubscriptionManager`` utility will be installed
+       in this site if one does not already exist, and the subscription will be created
+       there.
+
+       Second, if *for_* is not given, then the interfaces provided by the *resource* will
+       be used for *for_*. This doesn't actually subscribe
+       *just* to events on that exact object, but to events for objects with the same set of
+       interfaces.
+    """
+    if for_ is None:
+        for_ = providedBy(resource)
+
+    site_manager = getSiteManager(resource)
+    sub_name = 'WebhookSubscriptionManager'
+    if IContainer.providedBy(site_manager):
+        sub_manager = site_manager.get(sub_name) # pylint:disable=no-member
+        if sub_manager is None:
+            sub_manager = site_manager[sub_name] = PersistentWebhookSubscriptionManager()
+            site_manager.registerUtility(sub_manager, IWebhookSubscriptionManager)
+    else:
+        # Perhaps we should fail?
+        sub_manager = site_manager.getUtility(IWebhookSubscriptionManager)
+
+    subscription = sub_manager.createSubscription(to=to, for_=for_, when=when,
+                                                  dialect_id=dialect_id,
+                                                  owner_id=owner_id,
+                                                  permission_id=permission_id)
+    return subscription

--- a/src/nti/webhooks/delivery_manager.py
+++ b/src/nti/webhooks/delivery_manager.py
@@ -34,7 +34,7 @@ class _TrivialShipmentInfo(ShipmentInfo):
         # This doesn't handle persistent objects.
 
         # Sort them by URL so that requests to the same host go together;
-        # this may help with HTTP keepalive/pipeline
+        # this may help with HTTP keepalive/pipeline?
         self._sub_and_attempts = sorted(subscriptions_and_attempts,
                                         key=lambda sub_attempt: sub_attempt[0].to)
 
@@ -124,7 +124,6 @@ class DefaultDeliveryManager(Contained):
         return futures.ThreadPoolExecutor(thread_name_prefix='WebhookDeliveryManager')
 
     def createShipmentInfo(self, subscriptions_and_attempts):
-        # TODO: Group by domain and re-use request sessions.
         return _TrivialShipmentInfo(subscriptions_and_attempts)
 
     def acceptForDelivery(self, shipment_info):

--- a/src/nti/webhooks/delivery_manager.py
+++ b/src/nti/webhooks/delivery_manager.py
@@ -71,6 +71,8 @@ class _TrivialShipmentInfo(ShipmentInfo):
         _dict_to_text = dict
 
     def _fill_req_resp_from_request(self, attempt, http_response):
+        # This will ultimately run in a transaction of its own with access to the
+        # database.
         http_request = http_response.request # type: requests.PreparedRequest
         req = attempt.request
         rsp = attempt.response
@@ -115,7 +117,10 @@ class DefaultDeliveryManager(Contained):
 
     @Lazy
     def _pool(self):
-        # Delay creating a thread pool until used for monkey-patching
+        # Delay creating a thread pool until used to allow for monkey-patching
+        # TODO: Define an interface and utility for this so that we can customize
+        # it at test time. Specifically, we want to be able to ensure we use transactions
+        # that are explicit and that clean the DB caches when done. (mock_db_trans)
         return futures.ThreadPoolExecutor(thread_name_prefix='WebhookDeliveryManager')
 
     def createShipmentInfo(self, subscriptions_and_attempts):

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -455,8 +455,14 @@ class IWebhookSubscriptionManager(IContainerNamesContainer):
     """
     contains(IWebhookSubscription)
 
-    def addSubscription(subscription):
+    def createSubscription(to=None, for_=None, when=None,
+                           owner_id=None, permission_id=None,
+                           dialect=None):
         """
-        XXX: Document me.
-        :param subscription: A `IWebhookSubscription`.
+        Create and store a new ``IWebhookSubscription`` in this manager.
+
+        The new subscription is returned. It is a child of this object.
+
+        All arguments are by keyword, and have the same meaning as
+        the attributes documented.
         """

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -93,7 +93,8 @@ class IWebhookDeliveryManager(Interface):
         shipment info.
 
         For persistent subscriptions and attempts, all necessary information to complete
-        :meth:`acceptForDelivery` must be captured at this time.
+        :meth:`acceptForDelivery` must be captured at this time. The connection that created the
+        subscription and attempts must still be open, and the transaction still running.
 
         :return: A new :class:`IWebhookDeliveryManagerShipmentInfo` object.
             If the iterable is empty, this may return None or a suitable

--- a/src/nti/webhooks/subscribers.py
+++ b/src/nti/webhooks/subscribers.py
@@ -32,15 +32,15 @@ def find_active_subscriptions_for(data, event):
     # the ``__bases__`` of the site manager itself to walk up and find only the next utility.
     subscriptions = []
     provided = [providedBy(data), providedBy(event)]
-    last_sub_manager = None
+    seen_managers = set()
     for context in None, data:
         # A context of None means to use the current site manager.
         sub_managers = component.getUtilitiesFor(IWebhookSubscriptionManager, context)
         for _name, sub_manager in sub_managers:
-            if sub_manager is last_sub_manager:
+            if sub_manager in seen_managers:
                 # De-dup.
                 continue
-            last_sub_manager = sub_manager
+            seen_managers.add(sub_manager)
             local_subscriptions = sub_manager.registry.adapters.subscriptions(provided, None)
             subscriptions.extend(local_subscriptions)
     return subscriptions

--- a/src/nti/webhooks/subscribers.py
+++ b/src/nti/webhooks/subscribers.py
@@ -52,7 +52,9 @@ def dispatch_webhook_event(data, event):
 
     This is registered globally for ``(*, IObjectEvent)`` (TODO: It
     would be nice to make that more specific. Maybe we want to require
-    objects to implement the ``IWebhookPayload`` interface?.)
+    objects to implement an ``IWebhookPossiblePayload`` interface? Just in
+    order to cut down on the number of times this fires by default, which
+    is a LOT.)
 
     This function:
 
@@ -62,7 +64,13 @@ def dispatch_webhook_event(data, event):
       instances in the context of the *data*, which may be separate.
     - Determines if any of those actually apply to the *data*, and if so,
       joins the transaction to prepare for sending them.
+
+    .. caution::
+        This function assumes the global, thread-local transaction manager. If any
+        objects belong to ZODB connections that are using a different transaction
+        manager, this won't work.
     """
+    # TODO: I think we could actually find a differen transaction manager if we needed to.
     subscriptions = find_active_subscriptions_for(data, event)
     subscriptions = [sub for sub in subscriptions if sub.isApplicable(data)]
     if subscriptions:

--- a/src/nti/webhooks/testing.py
+++ b/src/nti/webhooks/testing.py
@@ -9,6 +9,9 @@ from __future__ import print_function
 
 import responses
 
+from nti.testing.zodb import mock_db_trans
+from nti.testing.zodb import ZODBLayer
+
 class UsingMocks(object):
     """
     Mocks :mod:`requests` using :mod:`responses`.
@@ -32,3 +35,35 @@ class UsingMocks(object):
 
     def finish(self):
         self.mock.stop()
+
+
+class DoctestTransaction(mock_db_trans):
+    """
+    Like :class:`nti.testing.zodb.mock_db_trans`, but
+    with methods that are prettier for use in doctests.
+    """
+
+    def begin(self):
+        return self.__enter__()
+
+    def finish(self):
+        return self.__exit__(None, None, None)
+
+class ZODBFixture(object):
+    """
+    Like :class:`nti.testing.zodb.ZODBLayer`, but
+    not a layer and meant for doctests.
+    """
+
+    @classmethod
+    def setUp(cls):
+        for c in reversed(ZODBLayer.__mro__):
+            if 'setUp' in c.__dict__:
+                c.__dict__['setUp'].__func__(c)
+
+
+    @classmethod
+    def tearDown(cls):
+        for c in ZODBLayer.__mro__:
+            if 'tearDown' in c.__dict__:
+                c.__dict__['tearDown'].__func__(c)

--- a/src/nti/webhooks/tests/test_subscriptions.py
+++ b/src/nti/webhooks/tests/test_subscriptions.py
@@ -11,8 +11,11 @@ from __future__ import print_function
 import unittest
 from hamcrest import assert_that
 from hamcrest import is_
+from hamcrest import is_not
 from hamcrest import same_instance
 from hamcrest import has_properties
+
+from zope import component
 
 from nti.webhooks import subscriptions
 
@@ -31,3 +34,10 @@ class TestGlobalWebhookSubscriptionManager(unittest.TestCase):
         assert_that(gsm_2.registry,
                     has_properties(adapters=same_instance(gsm.registry.adapters),
                                    utilities=same_instance(gsm.registry.utilities)))
+
+        site_man = component.getGlobalSiteManager()
+        assert_that(gsm_2.registry,
+                    has_properties(
+                        adapters=is_not(same_instance(site_man.adapters)),
+                        utilities=is_not(same_instance(site_man.utilities))
+                    ))

--- a/src/nti/webhooks/zcml.py
+++ b/src/nti/webhooks/zcml.py
@@ -13,7 +13,6 @@ from zope.interface import Interface
 
 from zope.security.zcml import Permission
 
-from nti.webhooks.subscriptions import Subscription
 from nti.webhooks.subscriptions import getGlobalSubscriptionManager
 from nti.webhooks.interfaces import IWebhookSubscription
 from nti.webhooks._schema import ObjectEventInterface
@@ -64,8 +63,7 @@ class IStaticSubscriptionDirective(Interface):
 
 
 def _static_subscription_action(subscription_kwargs):
-    subscription = Subscription(**subscription_kwargs)
-    getGlobalSubscriptionManager().addSubscription(subscription)
+    getGlobalSubscriptionManager().createSubscription(**subscription_kwargs)
 
 def static_subscription(context, **kwargs):
     to = kwargs.pop('to')
@@ -88,7 +86,6 @@ def static_subscription(context, **kwargs):
     context.action(
         # No conflicts. You can register as many identical hooks
         # as you want.
-        # TODO: What makes the most sense?
         discriminator=None,
         callable=_static_subscription_action,
         args=(subscription_kwargs,)


### PR DESCRIPTION
With tests, including one that demonstrates the hierarchy works even when the current site is not the site containing subscriptions, so long as the subscription is in the lineage.

This adds the first part of the high-level API that I expect to use to manage subscriptions.

Feedback very welcome!