### PR TITLE
Don't register the subscriber for (*, IObjectEvent) by default.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -364,6 +364,7 @@ intersphinx_mapping = {
 
     'https://zopeauthentication.readthedocs.io/en/latest/': None,
     'https://zopecomponent.readthedocs.io/en/latest/': None,
+    'https://zopeconfiguration.readthedocs.io/en/latest/': None,
     'https://zopecontainer.readthedocs.io/en/latest/': None,
     'https://zopeinterface.readthedocs.io/en/latest/': None,
     'https://zopelifecycleevent.readthedocs.io/en/latest/': None,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,134 @@
+===============
+ Configuration
+===============
+
+``nti.webhooks`` uses :mod:`zope.configuration.xmlconfig` and ZCML files for
+basic configuration.
+
+Loading the default ``configure.zcml`` for this package establishes
+some defaults, such as the default global :class:`webhook delivery
+manager <nti.webhooks.interfaces.IWebhookDeliveryManager>`.
+
+.. doctest::
+
+   >>> from zope.configuration import xmlconfig
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="nti.webhooks" />
+   ... </configure>
+   ... """)
+
+.. important::
+   By itself, that is not enough for this package to be functional.
+
+.. We link to the module because xrefs between projects for interfaces
+   are broken as of July 2020.
+
+The subscriber :func:`nti.webhooks.subscribers.dispatch_webhook_event`
+must be registered as well, for some combination of data object and
+(descendent of) :mod:`zope.interface.interfaces.IObjectEvent
+<zope.interface.interfaces>`.
+
+.. note:: Descending from ``IObjectEvent`` is not actually required,
+          so long as the event provides the ``object`` attribute, and
+          so long as double-dispatch from a single event to the double
+          ``(object, event)`` subscriber interface happens. This is
+          automatic for ``IObjectEvent``.
+
+Because ``IObjectEvent`` and its descendents are extremely common
+events, that subscriber is not registered by default. Doing so could
+add unacceptable overhead to common application actions. It is
+suggested that your application integration should register the
+subscriber for a subset of "interesting" events and data types.
+
+Your application integration is free to register the subscriber for
+exactly the events that are desired. Or, to assist with common cases,
+this package provides two additional ZCML files.
+
+Recommended: ``subscribers.zcml``
+=================================
+
+This file registers the subscriber for commonly useful object
+lifecycle events:
+
+- :mod:`zope.lifecycleevent.interfaces.IObjectAddedEvent <zope.lifecycleevent.interfaces>`
+- :mod:`zope.lifecycleevent.interfaces.IObjectModifiedEvent <zope.lifecycleevent.interfaces>`
+- :mod:`zope.lifecycleevent.interfaces.IObjectRemovedEvent <zope.lifecycleevent.interfaces>`
+
+.. note::
+
+   The ``IObjectCreatedEvent`` is specifically *not* registered. While
+   this is the first event typically sent during an object's
+   lifecycle, when it is fired, the object is not required to have a
+   location (``__name__`` and ``__parent__``) yet. It also typically
+   does not have proper security constraints yet (which are usually
+   location dependent). This means that URLs cannot be generated for
+   it, nor can security be enforced.
+
+Rather than register those for ``*``, meaning *any* object, those are
+registered for
+:class:`nti.webhooks.interfaces.IPossibleWebhookPayload`. This marker
+interface is meant to be mixed in by the application to classes that
+are subject to events and for which webhook delivery may be desired.
+
+.. note::
+
+   This is separate from
+   :class:`nti.webhooks.interfaces.IWebhookPayload`, which is used as
+   an adapter from an object delivered with an event to the object
+   that should actually be externalized for delivery of the event.
+
+
+For example:
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers.zcml" />
+   ...   <class class="nti.webhooks.testing.InterestingClass">
+   ... 	    <implements interface="nti.webhooks.interfaces.IPossibleWebhookPayload" />
+   ...   </class>
+   ... </configure>
+   ... """)
+
+
+Development and Testing: ``subscribers_promiscuous.zcml``
+=========================================================
+
+This file registers the dispatcher for *all* object events for *all*
+objects: ``(*, IObjectEvent*)``.
+
+This may have performance consequences, so its use in production
+systems is discouraged (unless the system is small). However, it is
+extremely useful during development and (unit) testing and while
+deciding which objects and events make useful webhooks.
+
+Many of the tests and examples in the documentation for this package
+use this file.
+
+For example:
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
+   ... </configure>
+   ... """)
+
+.. testcleanup::
+
+   from zope.testing import cleanup
+   cleanup.cleanUp()

--- a/docs/customizing_payloads.rst
+++ b/docs/customizing_payloads.rst
@@ -39,6 +39,7 @@ First, the imports and creation of the static subscription.
    ...   <include package="zope.component" />
    ...   <include package="zope.container" />
    ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
    ...   <webhooks:staticSubscription
    ...             to="https://example.com/some/path"
    ...             for="zope.container.interfaces.IContentContainer"

--- a/docs/dynamic.rst
+++ b/docs/dynamic.rst
@@ -115,6 +115,7 @@ Now we'll create a database and store our hierarchy.
    ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
    ...     >
    ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
    ...   <include package="nti.site" />
    ...   <include package="zope.traversing" />
    ... </configure>
@@ -327,6 +328,8 @@ TODO
 - Deleting subscriptions.
 - The interface/adapter to get what ``for_`` to use, instead of going directly to
   ``providedBy``.
+- Auto-deactivate subscriptions after: not finding principals, number of failed deliveries, etc.
+- Auto-copy principal from interaction when none is given.
 
 
 .. testcleanup::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Contents:
    :maxdepth: 1
 
    glossary
+   configuration
    static
    security
    customizing_payloads

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -89,6 +89,7 @@ that is used if the ``owner`` cannot be found at runtime:
    ...   <include package="zope.securitypolicy" />
    ...   <include package="zope.securitypolicy" file="securitypolicy.zcml" />
    ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
    ...   <webhooks:staticSubscription
    ...             to="https://this_domain_does_not_exist"
    ...             for="zope.container.interfaces.IContentContainer"

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -24,8 +24,8 @@ Let's look at an example of how to use this directive from ZCML. We
 need to define the XML namespace it's in, and we need to include the
 configuration file that defines it. We also need to have the event
 dispatching provided by :mod:`zope.component` properly set up, as well
-as some other things. Including this package's configuration handles
-all of that.
+as some other things described in :doc:`configuration`. Including this
+package's configuration handles all of that.
 
 .. doctest::
 
@@ -36,6 +36,7 @@ all of that.
    ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
    ...     >
    ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
    ... </configure>
    ... """, execute=False)
 
@@ -116,6 +117,7 @@ deliver a webhook.
    ...   <include package="zope.component" />
    ...   <include package="zope.container" />
    ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
    ...   <webhooks:staticSubscription
    ...             to="https://this_domain_does_not_exist"
    ...             for="zope.container.interfaces.IContentContainer"
@@ -242,6 +244,7 @@ Let's reset things and look at what a successful delivery might look like.
    ...   <include package="zope.component" />
    ...   <include package="zope.container" />
    ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
    ...   <webhooks:staticSubscription
    ...             to="https://example.com/some/path"
    ...             for="zope.container.interfaces.IContentContainer"

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -37,12 +37,7 @@
     <!-- The default dialect -->
     <utility factory=".dialect.DefaultWebhookDialect" />
 
-    <!-- Global event dispatcher -->
-    <subscriber
-        for="* zope.interface.interfaces.IObjectEvent"
-        handler=".subscribers.dispatch_webhook_event"
-        trusted="true"
-        />
+    <!-- Global event dispatchers are configured in subscribers.zcml -->
 
 
 </configure>

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 from zope.interface import Interface
 from zope.interface import Attribute
+from zope.interface import taggedValue
 from zope.interface.interfaces import IInterface
 from zope.interface.interfaces import IObjectEvent
 
@@ -151,17 +152,27 @@ class IWebhookDestinationValidator(Interface):
         :exc:`socket.error` for unresolvable domains.
         """
 
+class IPossibleWebhookPayload(Interface):
+    """
+    Marker interface applied to objects that may have webhook
+    subscriptions defined for them.
+
+    The default configuration in ``subscribers.zcml`` loads event
+    dispatchers only for event targets that implement this interface.
+    """
+
+    taggedValue('_ext_is_marker_interface', True)
+
 
 class IWebhookPayload(Interface):
     """
-    Marker interface for objects that can automatically
-    become the payload of a webhook.
-
-    This interface is used as the default in a number of
-    places.
-
-    TODO: More docs as this evolves.
+    Adapter interface to convert an object that is a
+    target of an event (possibly a `IPossibleWebhookPayload`)
+    into the object that should actually be used as the payload.
     """
+
+    taggedValue('_ext_is_marker_interface', True)
+
 
 class IWebhookDialect(Interface):
     """

--- a/src/nti/webhooks/subscribers.py
+++ b/src/nti/webhooks/subscribers.py
@@ -47,25 +47,28 @@ def find_active_subscriptions_for(data, event):
 
 def dispatch_webhook_event(data, event):
     """
-    A subcriber installed globally to dispatch events to webhook
-    subscriptions.
+    A subcriber installed to dispatch events to webhook subscriptions.
 
-    This is registered globally for ``(*, IObjectEvent)`` (TODO: It
-    would be nice to make that more specific. Maybe we want to require
-    objects to implement an ``IWebhookPossiblePayload`` interface? Just in
-    order to cut down on the number of times this fires by default, which
-    is a LOT.)
+    This is usually registered in the global registry by loading
+    ``subscribers.zcml`` or ``subscribers_promiscuous.zcml``, but the
+    event and data for which it is registered may be easily
+    customized. See :doc:`/configuration` for more information.
 
     This function:
 
-    - Queries for all active subscriptions in the ``IWebhookSubscriptionManager``
-      instances in the current site hierarchy;
-    - And queries for all active subscriptions in the ``IWebhookSubscriptionManager``
-      instances in the context of the *data*, which may be separate.
-    - Determines if any of those actually apply to the *data*, and if so,
-      joins the transaction to prepare for sending them.
+        - Queries for all active subscriptions in the
+          ``IWebhookSubscriptionManager`` instances in the current
+          site hierarchy;
+
+        - And queries for all active subscriptions in the
+          ``IWebhookSubscriptionManager`` instances in the context of
+          the *data*, which may be separate.
+
+        - Determines if any of those actually apply to the *data*, and
+          if so, joins the transaction to prepare for sending them.
 
     .. caution::
+
         This function assumes the global, thread-local transaction manager. If any
         objects belong to ZODB connections that are using a different transaction
         manager, this won't work.

--- a/src/nti/webhooks/subscribers.zcml
+++ b/src/nti/webhooks/subscribers.zcml
@@ -1,0 +1,28 @@
+<!-- -*- mode: nxml -*- -->
+<configure  xmlns="http://namespaces.zope.org/zope"
+            xmlns:i18n="http://namespaces.zope.org/i18n"
+            xmlns:zcml="http://namespaces.zope.org/zcml"
+            xmlns:meta="http://namespaces.zope.org/meta">
+
+    <include package="zope.component" file="meta.zcml" />
+
+    <!-- Limited, opt-in global event dispatcher. -->
+    <!-- Any changes need to be documented in configuration.rst -->
+    <subscriber
+        for=".interfaces.IPossibleWebhookPayload zope.lifecycleevent.interfaces.IObjectAddedEvent"
+        handler=".subscribers.dispatch_webhook_event"
+        trusted="true"
+        />
+    <subscriber
+        for=".interfaces.IPossibleWebhookPayload zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+        handler=".subscribers.dispatch_webhook_event"
+        trusted="true"
+        />
+    <subscriber
+        for=".interfaces.IPossibleWebhookPayload zope.lifecycleevent.interfaces.IObjectRemovedEvent"
+        handler=".subscribers.dispatch_webhook_event"
+        trusted="true"
+        />
+
+
+</configure>

--- a/src/nti/webhooks/subscribers_promiscuous.zcml
+++ b/src/nti/webhooks/subscribers_promiscuous.zcml
@@ -1,0 +1,18 @@
+<!-- -*- mode: nxml -*- -->
+<configure  xmlns="http://namespaces.zope.org/zope"
+            xmlns:i18n="http://namespaces.zope.org/i18n"
+            xmlns:zcml="http://namespaces.zope.org/zcml"
+            xmlns:meta="http://namespaces.zope.org/meta">
+
+    <include package="zope.component" file="meta.zcml" />
+
+    <!-- Inclusive, global event dispatcher. -->
+    <!-- This is primarily intended for testing and development. -->
+    <!-- Loading it may have performance consequences. -->
+    <!-- Any changes need to be documented in configuration.rst -->
+    <subscriber
+        for="* zope.interface.interfaces.IObjectEvent"
+        handler=".subscribers.dispatch_webhook_event"
+        trusted="true"
+        />
+</configure>

--- a/src/nti/webhooks/testing.py
+++ b/src/nti/webhooks/testing.py
@@ -92,3 +92,12 @@ class SequentialExecutorService(object):
 
     def shutdown(self):
         self.to_run = None
+
+
+class InterestingClass(object):
+    """
+    A class we refer to (and manipulate) in documentation.
+
+    Do not depend on anything specific about this class
+    other than its existence.
+    """


### PR DESCRIPTION
Don't register it all, by default. Make users opt-in to something.

Provide two files that register the subscriber. One for a marker
interface and relevant lifecycle details, and one that does the
previous behaviour.