### PR TITLE
Implement length limits for delivery attempt history

### DIFF
--- a/docs/delivery_attempts.rst
+++ b/docs/delivery_attempts.rst
@@ -1,0 +1,178 @@
+==================
+ Delivery History
+==================
+
+.. currentmodule:: nti.webhooks.interfaces
+
+.. testsetup::
+
+   from zope.testing import cleanup
+   from nti.webhooks.testing import UsingMocks
+
+
+All attempts at delivering a webhook are recorded as an object that
+implements :class:`IWebhookDeliveryAttempt`.
+For static subscriptions, these are only in memory on a single
+machine, but :doc:`persistent, dynamic, subscriptions <dynamic>` that
+record their history more durably are also possible.
+
+Delivery always occurs as a result of committing a transaction, and
+the resulting attempt object is stored in the corresponding
+subscription object. There are three types of delivery attempts:
+pending, unsuccessful, and successful. A pending attempt is one that
+hasn't yet been resolved, while the other two have been resolved.
+
+Failed Delivery Attempts
+========================
+
+A delivery attempt fails when:
+
+- The subscription was :term:`active`; and
+- The subscription was :term:`applicable`; and
+- Some error occurred communicating with :term:`target`. Such errors
+  include (but are not limited to) failed DNS lookups and HTTP error
+  responses.
+
+Successful Delivery Attempts
+============================
+
+Successful delivery attempts are more interesting. Lets look at one of
+those and describe the ``IWebhookDeliveryAttempt``. We begin by
+defining a subscription.
+
+.. doctest::
+
+   >>> from zope.configuration import xmlconfig
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="zope.component" />
+   ...   <include package="zope.container" />
+   ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
+   ...   <webhooks:staticSubscription
+   ...             to="https://example.com/some/path"
+   ...             for="zope.container.interfaces.IContentContainer"
+   ...             when="zope.lifecycleevent.interfaces.IObjectCreatedEvent" />
+   ... </configure>
+   ... """)
+
+Now we can access the subscription. Because delivery attempts are
+stored in the subscription, it has a length of 0 at this time.
+
+.. doctest::
+
+
+   >>> from zope import component
+   >>> from nti.webhooks import interfaces
+   >>> sub_manager = component.getUtility(interfaces.IWebhookSubscriptionManager)
+   >>> subscription = sub_manager['Subscription']
+   >>> len(subscription)
+   0
+
+
+To avoid actually trying to talk to example.com, we'll be using some mocks.
+
+.. doctest::
+
+   >>> from nti.webhooks.testing import mock_delivery_to
+   >>> mock_delivery_to('https://example.com/some/path', method='POST', status=200)
+
+Now we will create the object, broadcast the event to engage the
+subscription, and commit the transaction to send the hook.
+
+.. doctest::
+
+   >>> import transaction
+   >>> from zope import lifecycleevent
+   >>> from zope.container.folder import Folder
+   >>> _ = transaction.begin()
+   >>> lifecycleevent.created(Folder())
+   >>> transaction.commit()
+
+In the background, the `IWebhookDeliveryManager` is busy invoking the hook. We need to wait for it to
+finish, and then we can examine our delivery attempt:
+
+.. doctest::
+
+   >>> from zope import component
+   >>> from nti.webhooks.interfaces import IWebhookDeliveryManager
+   >>> component.getUtility(IWebhookDeliveryManager).waitForPendingDeliveries()
+
+Attempt Details
+---------------
+
+The subscription now has an attempt recorded in the form of an
+``IWebhookDeliveryAttempt``. The attempt records some basic details,
+such as the overall status, and an associated message.
+
+.. important::
+
+   Attempts are immutable. They are created and managed entirely by
+   the system and mutation attempts are not allowed.
+
+
+.. doctest::
+
+   >>> len(subscription)
+   1
+   >>> attempt = subscription.pop()
+   >>> from zope.interface import verify
+   >>> verify.verifyObject(interfaces.IWebhookDeliveryAttempt, attempt)
+   True
+   >>> attempt.status
+   'successful'
+   >>> print(attempt.message)
+   200 OK
+
+An important attribute of the attempt is the ``request``; this
+attribute (an `IWebhookDeliveryAttemptRequest`) provides information
+about the HTTP request as it went on the wire.
+
+.. doctest::
+
+   >>> verify.verifyObject(interfaces.IWebhookDeliveryAttemptRequest, attempt.request)
+   True
+   >>> print(attempt.request.url)
+   https://example.com/some/path
+   >>> print(attempt.request.method)
+   POST
+   >>> import pprint
+   >>> pprint.pprint({str(k): str(v) for k, v in attempt.request.headers.items()})
+   {'Accept': '*/*',
+    'Accept-Encoding': 'gzip, deflate',
+    'Connection': 'keep-alive',
+    'Content-Length': '94',
+    'Content-Type': 'application/json',
+    'User-Agent': 'nti.webhooks ...'}
+   >>> print(attempt.request.body)
+   {"Class": "NonExternalizableObject", "InternalType": "<class 'zope.container.folder.Folder'>"}
+
+(If you're curious about that "NonExternalizableObject" business, then see :doc:`customizing_payloads`.)
+
+Another important attribute is the ``response`` (an
+`IWebhookDeliveryAttemptResponse`), which captures information about
+the data received from the :term:`target`.
+
+.. doctest::
+
+   >>> verify.verifyObject(interfaces.IWebhookDeliveryAttemptResponse, attempt.response)
+   True
+   >>> attempt.response.status_code
+   200
+   >>> print(attempt.response.reason)
+   OK
+   >>> pprint.pprint({str(k): str(v) for k, v in attempt.response.headers.items()})
+   {'Content-Type': 'text/plain'}
+   >>> print(attempt.response.content)
+   <BLANKLINE>
+   >>> attempt.response.elapsed
+   datetime.timedelta(...)
+
+
+.. testcleanup::
+
+   from zope.testing import cleanup
+   cleanup.cleanUp()

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -1,0 +1,8 @@
+========
+ Events
+========
+
+This document describes the events that are fired specific to this
+package.
+
+TODO: Do that.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -49,3 +49,6 @@
       used to create and populate the HTTP request.
 
       .. seealso:: :class:`IWebhookDialect` and :class:`nti.webhooks.dialect.DefaultWebhookDialect`
+
+   target
+      Of a subscription: The URL to which the HTTP request is sent.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Contents:
    static
    security
    customizing_payloads
+   delivery_attempts
    dynamic
    api/index
    changelog
@@ -27,6 +28,9 @@ TODO
 ====
 
 - Limited buffer for delivery attempts.
+- Externalization
+- Store some extra machine info on pending requests to help determine
+  if they're still viable or should be redone.
 
 Dynamic-subscriptions only
 --------------------------
@@ -41,6 +45,9 @@ Dynamic-subscriptions only
 - Auto-copy principal from interaction when none is given.
 - What about using nti.externalizations (?) "find primary interface"
   function as a generic ``IWebhookResourceDiscriminator``?
+- Use the nti.zodb properties for the created/last modified time, as
+  appropriate.
+
 
 Thoughts on HTTP API
 --------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Contents:
    customizing_payloads
    delivery_attempts
    dynamic
+   events
    api/index
    changelog
 
@@ -27,10 +28,11 @@ Contents:
 TODO
 ====
 
-- Limited buffer for delivery attempts.
 - Externalization
 - Store some extra machine info on pending requests to help determine
   if they're still viable or should be redone.
+- Store some exception info on failed requests (including those that
+  don't pass the validator) for debugging purposes.
 
 Dynamic-subscriptions only
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'zope.vocabularyregistry',
         'zope.site',
         'nti.site',
+        'nti.zodb',
         'nti.externalization >= 2.0.0', # Consistent interface resolution order
         'nti.schema',
         'setuptools',

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -28,6 +28,10 @@
     <utility component=".subscriptions.global_subscription_manager"
              provides=".interfaces.IWebhookSubscriptionManager" />
 
+    <!-- Managing the size of subscription histories. -->
+    <subscriber handler=".subscriptions.prune_subscription_when_resolved"
+                trusted="true" />
+
     <!-- The default validator -->
     <utility factory=".destination_validator.DefaultDestinationValidator" />
 

--- a/src/nti/webhooks/delivery_manager.py
+++ b/src/nti/webhooks/delivery_manager.py
@@ -195,7 +195,7 @@ class ShipmentInfo(object):
                     # or other.
                 except Exception as ex: # pylint:disable=broad-except
                     logger.exception("Failed to parse response for attempt %s", attempt)
-                    attempt.message = str(ex)
+                    attempt.message = text_type(ex)
 
     if str is bytes:
         @staticmethod

--- a/src/nti/webhooks/testing.py
+++ b/src/nti/webhooks/testing.py
@@ -112,6 +112,9 @@ def begin_synchronous_delivery():
     from nti.webhooks.interfaces import IWebhookDeliveryManager
     component.getUtility(IWebhookDeliveryManager).executor_service = SequentialExecutorService()
 
+#: Alternate name for `begin_synchronous_delivery` that may
+#: be more descriptive in some circumstances.
+begin_deferred_delivery = begin_synchronous_delivery
 
 _current_mocks = None
 

--- a/src/nti/webhooks/testing.py
+++ b/src/nti/webhooks/testing.py
@@ -8,6 +8,7 @@ from __future__ import division
 from __future__ import print_function
 
 from zope import interface
+from zope import component
 
 import responses
 
@@ -33,7 +34,8 @@ class UsingMocks(object):
     def __init__(self, *args, **kwargs):
         self.mock = responses.RequestsMock()
         self.mock.start()
-        self.add(*args, **kwargs)
+        if args or kwargs:
+            self.add(*args, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self.mock, name)
@@ -78,6 +80,8 @@ class ZODBFixture(object):
 class SequentialExecutorService(object):
     """
     Runs tasks one at a time, and only when waited on.
+
+    The preferred interface to this is :func:`begin_synchronous_delivery`.
     """
     def __init__(self):
         self.to_run = []
@@ -93,6 +97,43 @@ class SequentialExecutorService(object):
     def shutdown(self):
         self.to_run = None
 
+
+def begin_synchronous_delivery():
+    """
+    Cause the global ``IWebhookDeliveryManager`` to begin delivering
+    new shipments synchronously.
+
+    All deliveries are queued until ``waitForPendingDeliveries`` is
+    called; exceptions will be raised from that function.
+
+    This remains in effect until the test is torn down with
+    :mod:`zope.testing.cleanup`.
+    """
+    from nti.webhooks.interfaces import IWebhookDeliveryManager
+    component.getUtility(IWebhookDeliveryManager).executor_service = SequentialExecutorService()
+
+
+_current_mocks = None
+
+def mock_delivery_to(url, method='POST', status=200):
+    global _current_mocks # pylint:disable=global-statement
+    if _current_mocks is None:
+        _current_mocks = UsingMocks()
+    _current_mocks.add(method, url, status=status)
+
+
+def _clear_mocks():
+    global _current_mocks # pylint:disable=global-statement
+    if _current_mocks is not None:
+        _current_mocks.finish()
+    _current_mocks = None
+
+try:
+    from zope.testing import cleanup # pylint:disable=ungrouped-imports
+except ImportError:
+    pass
+else:
+    cleanup.addCleanUp(_clear_mocks)
 
 class InterestingClass(object):
     """

--- a/tox.ini
+++ b/tox.ini
@@ -38,3 +38,9 @@ extras = docs
 basepython = python2.7
 commands =
     sphinx-build -b doctest -d docs/_build/doctrees2 docs docs/_build/doctests2
+
+[testenv:docspypy]
+extras = docs
+basepython = pypy
+commands =
+    sphinx-build -b doctest -d docs/_build/doctreespypy2 docs docs/_build/doctestspypy2


### PR DESCRIPTION
This also implements events for when a delivery attempt succeeds or fails, but that's not specifically tested yet.