### PR TITLE
Store internal debugging info on attempts.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -367,6 +367,7 @@ intersphinx_mapping = {
     'https://zopecomponent.readthedocs.io/en/latest/': None,
     'https://zopeconfiguration.readthedocs.io/en/latest/': None,
     'https://zopecontainer.readthedocs.io/en/latest/': None,
+    'https://zopeevent.readthedocs.io/en/latest/': None,
     'https://zopeinterface.readthedocs.io/en/latest/': None,
     'https://zopelifecycleevent.readthedocs.io/en/latest/': None,
     'https://zopelocation.readthedocs.io/en/latest/': None,
@@ -375,6 +376,7 @@ intersphinx_mapping = {
     'https://zopesite.readthedocs.io/en/latest/': None,
     'https://zopetraversing.readthedocs.io/en/latest/': None,
 
+    'https://ntiexternalization.readthedocs.io/en/latest/': None,
     'https://ntitesting.readthedocs.io/en/latest/': None,
     'https://ntischema.readthedocs.io/en/latest/': None,
     'https://ntisite.readthedocs.io/en/latest/': None,

--- a/docs/dynamic.rst
+++ b/docs/dynamic.rst
@@ -352,6 +352,8 @@ static/global subscription delivery failed.
    >>> attempt = global_subscription.pop()
    >>> print(attempt.status)
    failed
+   >>> print(attempt.message)
+   404 Not Found
    >>> attempt.response.status_code
    404
    >>> print(attempt.request.url)
@@ -368,7 +370,8 @@ static/global subscription delivery failed.
     'User-Agent': 'nti.webhooks...'}
    >>> print(attempt.request.body)
    "Bob"
-
+   >>> len(attempt.internal_info.exception_history)
+   0
 
 
 .. testcleanup::

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -52,3 +52,7 @@
 
    target
       Of a subscription: The URL to which the HTTP request is sent.
+
+   externalized
+      Of an object: Written out in a format suitable for use in an
+      HTTP REST API, such as JSON, using :mod:`nti.externalization`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,11 +29,6 @@ TODO
 ====
 
 .. todo:: Externalization
-.. todo::  Store some extra machine info on attempts to help determine
-           if they're still viable or should be redone. E.g., host
-           name, pid.
-.. todo::  Store some exception info on failed requests (including those that
-           don't pass the validator) for debugging purposes.
 .. todo:: Write events document.
 
 Dynamic-subscriptions only
@@ -44,7 +39,7 @@ Dynamic-subscriptions only
            have an example with static subscriptions). Maybe triggering on a
            different event type would be good too.
 .. todo::  Add test to add new subscription when manager already exists.
-.. todo:: API for deleting subscriptions.
+.. todo::  API for deleting subscriptions.
 .. todo::  Auto-deactivate subscriptions after: not finding principals, number of failed deliveries, etc.
 .. todo::  Auto-copy principal from interaction when none is given.
 .. todo::  What about using nti.externalizations (?) "find primary interface"

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -236,8 +236,11 @@ But it does record a failed attempt in the subscription:
    'failed'
    >>> print(attempt.message)
    Verification of the destination URL failed. Please check the domain.
-
-
+   >>> len(attempt.internal_info.exception_history)
+   1
+   >>> print(attempt.internal_info.exception_history[0])
+   Traceback (most recent call last):
+   ...
 
 
 .. _z3c.baseregistry: https://github.com/zopefoundation/z3c.baseregistry/tree/master/src/z3c/baseregistry

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ entry_points = {
 TESTS_REQUIRE = [
     'coverage',
     'nti.testing',
+    'fudge',
     'zope.testrunner',
     'zope.lifecycleevent',
     'zope.securitypolicy', # ZCML directives for granting/denying

--- a/src/nti/webhooks/_util.py
+++ b/src/nti/webhooks/_util.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+Small helper functions used in multiple places.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import io
+from zope.exceptions import print_exception as zprint_exceptions
+
+NativeStringIO = io.StringIO if str is not bytes else io.BytesIO
+text_type = type(u'')
+
+def print_exception_to_text(exc_info):
+    f = NativeStringIO()
+    zprint_exceptions(exc_info[0], exc_info[1], exc_info[2],
+                      file=f, with_filenames=False)
+    printed = f.getvalue()
+    if isinstance(printed, bytes):
+        result = printed.decode('latin-1')
+    else:
+        result = printed
+    return result

--- a/src/nti/webhooks/attempts.py
+++ b/src/nti/webhooks/attempts.py
@@ -7,9 +7,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+from collections import namedtuple
 import time
+import socket
 
+import transaction
 from persistent import Persistent
+from persistent.list import PersistentList
+from persistent.interfaces import IPersistent
 from zope.interface import implementer
 from zope.schema.fieldproperty import createFieldProperties
 from zope.container.contained import Contained
@@ -19,12 +25,20 @@ from zope.lifecycleevent import Attributes
 
 from nti.schema.schema import SchemaConfigured
 
+from nti.webhooks._util import print_exception_to_text
+from nti.webhooks._util import text_type
+
 from nti.webhooks.interfaces import IWebhookDeliveryAttempt
 from nti.webhooks.interfaces import IWebhookDeliveryAttemptRequest
 from nti.webhooks.interfaces import IWebhookDeliveryAttemptResponse
 from nti.webhooks.interfaces import IWebhookDeliveryAttemptSucceededEvent
 from nti.webhooks.interfaces import IWebhookDeliveryAttemptFailedEvent
+from nti.webhooks.interfaces import IWebhookDeliveryAttemptInternalInfo
 
+
+###
+# Events
+###
 
 class WebhookDeliveryAttemptResolvedEvent(ObjectModifiedEvent):
     _ATTR = Attributes(IWebhookDeliveryAttempt, 'status')
@@ -41,10 +55,55 @@ class WebhookDeliveryAttemptSucceededEvent(WebhookDeliveryAttemptResolvedEvent):
 class WebhookDeliveryAttemptFailedEvent(WebhookDeliveryAttemptResolvedEvent):
     success = False
 
+###
+# Origination Info
+###
+DeliveryOriginationInfo = namedtuple(
+    'DeliveryOriginationInfo',
+    ('pid', 'hostname', 'createdTime', 'transaction_note',)
+)
 
+# The origination info itself is also immutable, though the exception
+# history may change.
+@implementer(IWebhookDeliveryAttemptInternalInfo)
+class WebhookDeliveryAttemptInternalInfo(Contained):
 
+    exception_history = ()
+
+    def __init__(self):
+        now = self.createdTime = time.time()
+        pid = os.getpid()
+        hostname = socket.gethostname()
+        transaction_note = transaction.get().description
+        self.originated = DeliveryOriginationInfo(
+            pid,
+            hostname,
+            now,
+            transaction_note,
+        )
+
+    def storeExceptionInfo(self, exc_info):
+        self.storeExceptionText(print_exception_to_text(exc_info))
+
+    def storeExceptionText(self, text):
+        """
+        Store an exception text, usually as created by
+        :func:`nti.webhooks._util.print_exception_to_text`
+        """
+        if self.exception_history == ():
+            if IPersistent.providedBy(self.__parent__):
+                self.__parent__._p_changed = True # pylint:disable=protected-access
+                self.exception_history = PersistentList()
+            else:
+                self.exception_history = []
+        assert isinstance(text, text_type)
+        self.exception_history.append(text)
+
+###
+# Requests and responses.
 # Requests and responses are immutable. Thus they are never
 # persistent.
+###
 
 class _Base(SchemaConfigured):
 
@@ -97,6 +156,7 @@ class _StatusDescriptor(object):
 @implementer(IWebhookDeliveryAttempt)
 class WebhookDeliveryAttempt(_Base, Contained):
     status = None
+    internal_info = None
     createFieldProperties(IWebhookDeliveryAttempt)
     # Allow delayed validation for these things.
     request = None
@@ -109,6 +169,10 @@ class WebhookDeliveryAttempt(_Base, Contained):
             self.request = WebhookDeliveryAttemptRequest()
         if self.response is None:
             self.response = WebhookDeliveryAttemptResponse()
+
+        self.internal_info = WebhookDeliveryAttemptInternalInfo()
+        self.internal_info.__parent__ = self
+        self.internal_info.__name__ = 'internal_info'
 
     def __repr__(self):
         return "<%s.%s at 0x%x status=%r>" % (

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -346,6 +346,27 @@ class _StatusField(Choice):
     def isResolved(self, status):
         return self.isFailure(status) or self.isSuccess(status)
 
+class IWebhookDeliveryAttemptInternalInfo(ICreatedTime):
+    """
+    Internal (debugging) information stored with a delivery
+    attempt.
+
+    This data is never externalized and is only loosely specified.
+
+    It may change over time.
+    """
+
+    exception_history = Attribute(
+        "A sequence (oldest to newest) of information "
+        "about exceptions encountered processing the attempt."
+    )
+
+    originated = Attribute(
+        "Information about where and how the request originated. "
+        "This can be used to see if it might still be pending or if "
+        "the instance has gone away."
+    )
+
 
 class IWebhookDeliveryAttempt(IContained, ILastModified):
     """
@@ -363,6 +384,7 @@ class IWebhookDeliveryAttempt(IContained, ILastModified):
         required=False,
     )
 
+    internal_info = Object(IWebhookDeliveryAttemptInternalInfo, required=True)
     request = Object(IWebhookDeliveryAttemptRequest, required=True)
     response = Object(IWebhookDeliveryAttemptResponse, required=True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,13 +31,13 @@ parallel_show_output = true
 extras = docs
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
-    sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctests
+    coverage run -p -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
 
 [testenv:docs2]
 extras = docs
 basepython = python2.7
 commands =
-    sphinx-build -b doctest -d docs/_build/doctrees2 docs docs/_build/doctests2
+    coverage run -p -m sphinx -b doctest -d docs/_build/doctrees2 docs docs/_build/doctests2
 
 [testenv:docspypy]
 extras = docs


### PR DESCRIPTION
- Where and when it was originally created, and by what transaction.
- Any exceptions that happened.