### PR TITLE
Handling of failed deliveries and applicability tests

### DIFF
--- a/docs/delivery_attempts.rst
+++ b/docs/delivery_attempts.rst
@@ -263,6 +263,10 @@ per-principal.
 
 .. doctest::
 
+   >>> from nti.webhooks.interfaces import ILimitedAttemptWebhookSubscription
+   >>> from zope.interface import verify
+   >>> verify.verifyObject(ILimitedAttemptWebhookSubscription, subscription)
+   True
    >>> subscription.attempt_limit
    50
 
@@ -310,6 +314,14 @@ and as the newer attempts complete, they will replace them.
    False
    >>> attempt_50 in all_attempts
    True
+
+
+.. todo:: We need to test this case for failures, both
+          at HTTP delivery time, and at DNS domain validation time.
+          I suspect the DNS domain validation time won't work, because
+          there's no parent set yet when the event goes out.
+
+          This should result in deactivating the subscription.
 
 .. testcleanup::
 

--- a/docs/delivery_helper.py
+++ b/docs/delivery_helper.py
@@ -1,6 +1,5 @@
 import transaction
 from zope import lifecycleevent
-from zope import component
 from zope import interface
 from zope.container.folder import Folder
 from zope.securitypolicy.interfaces import IPrincipalPermissionManager
@@ -8,7 +7,12 @@ from zope.annotation.interfaces import IAttributeAnnotatable
 
 from nti.testing.time import time_monotonically_increases
 
-from nti.webhooks.interfaces import IWebhookDeliveryManager
+from nti.webhooks.testing import wait_for_deliveries
+
+__all__ = [
+    'deliver_some',
+    'wait_for_deliveries',
+]
 
 @time_monotonically_increases
 def deliver_some(how_many=1, note=None, grants=None):
@@ -26,7 +30,3 @@ def deliver_some(how_many=1, note=None, grants=None):
                 prin_perm.grantPermissionToPrincipal(perm_id, principal_id)
         lifecycleevent.created(content)
         transaction.commit()
-
-def wait_for_deliveries():
-    delivery_man = component.getUtility(IWebhookDeliveryManager)
-    delivery_man.waitForPendingDeliveries()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,8 @@ TODO
           created/modified time properties as ISO format strings, not
           numbers for zapier.
 .. todo:: Write events document.
-
+.. todo:: Implement IDCTimes in terms of the native object
+          properties. There's a helper function for this.
 
 Dynamic-subscriptions only
 --------------------------
@@ -46,8 +47,9 @@ Dynamic-subscriptions only
 .. todo::  Add test to add new subscription when manager already exists.
 .. todo::  API for deleting subscriptions. Probably done by finding
            all subscriptions for a resource/principal.
-.. todo::  Auto-deactivate subscriptions after: not finding principals, number of failed deliveries, etc.
-.. todo::  Auto-copy principal from interaction when none is given.
+.. todo::  Auto-deactivate subscriptions after: applicability failures
+           (e.g., not finding principals)
+.. todo::  Auto-copy principal from interaction when none is given in api?
 .. todo::  What about using nti.externalizations (?) "find primary interface"
            function as a generic ``IWebhookResourceDiscriminator``?
 .. todo::  Use the nti.zodb properties for the created/last modified time, as

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -35,7 +35,10 @@
     <!-- Managing the size of subscription histories. -->
     <subscriber handler=".subscriptions.prune_subscription_when_resolved"
                 trusted="true" />
+    <!-- Deactivating subscriptions on certain conditions. -->
     <subscriber handler=".subscriptions.deactivate_subscription_when_all_failed"
+                trusted="true" />
+    <subscriber handler=".subscriptions.deactivate_subscription_when_applicable_limit_exceeded"
                 trusted="true" />
     <!-- Internal state handling -->
     <subscriber handler=".subscriptions.sync_active_status_registered"

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -2,7 +2,8 @@
 <configure  xmlns="http://namespaces.zope.org/zope"
             xmlns:i18n="http://namespaces.zope.org/i18n"
             xmlns:zcml="http://namespaces.zope.org/zcml"
-            xmlns:meta="http://namespaces.zope.org/meta">
+            xmlns:meta="http://namespaces.zope.org/meta"
+            i18n_domain="nti.webhooks">
 
     <include package="zope.component" file="meta.zcml" />
     <include package="." file="meta.zcml" />
@@ -33,6 +34,8 @@
 
     <!-- Managing the size of subscription histories. -->
     <subscriber handler=".subscriptions.prune_subscription_when_resolved"
+                trusted="true" />
+    <subscriber handler=".subscriptions.deactivate_subscription_when_all_failed"
                 trusted="true" />
     <!-- Internal state handling -->
     <subscriber handler=".subscriptions.sync_active_status_registered"

--- a/src/nti/webhooks/datamanager.py
+++ b/src/nti/webhooks/datamanager.py
@@ -153,6 +153,7 @@ class WebhookDataManager(object):
         for subscription in subscriptions:
             # pylint:disable=protected-access
             if IPersistent.providedBy(subscription) and subscription._p_jar and subscription._p_oid:
+                # See comment below for why we must do this.
                 subscription._p_jar.register(subscription)
 
 
@@ -179,6 +180,9 @@ class WebhookDataManager(object):
     # which in turn registers with the transaction, as soon as they are added to this
     # data manager. Another approach would be to add a before-commit transaction hook
     # to the transaction that does the same thing.
+    #
+    # Another option might be to create the delivery attempt much earlier? But
+    # that would forbid any attempt from coalescing events, wouldn't it.
 
     @foreign_transaction
     def tpc_begin(self, transaction):

--- a/src/nti/webhooks/delivery_manager.py
+++ b/src/nti/webhooks/delivery_manager.py
@@ -22,7 +22,7 @@ from zope.cachedescriptors.property import Lazy
 from persistent.interfaces import IPersistent
 from ZODB.interfaces import IDatabase
 
-from nti.transactions.transactions import TransactionLoop
+from nti.transactions.loop import TransactionLoop
 
 from nti.webhooks import MessageFactory as _
 from nti.webhooks._util import print_exception_to_text

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -563,6 +563,12 @@ class IWebhookSubscription(IContainerNamesContainer):
         readonly=True,
     )
 
+    status_message = Text(
+        title=u"Explanatory text about the state of this subscription.",
+        required=True,
+        default=u'Active',
+    )
+
 
 class ILimitedAttemptWebhookSubscription(IWebhookSubscription):
     """

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -10,6 +10,8 @@ from __future__ import print_function
 from zope.interface import Interface
 from zope.interface import Attribute
 from zope.interface import taggedValue
+from zope.interface import implementer
+
 from zope.interface.interfaces import IInterface
 from zope.interface.interfaces import IObjectEvent
 from zope.interface.interfaces import ObjectEvent
@@ -580,7 +582,9 @@ class ILimitedAttemptWebhookSubscription(IWebhookSubscription):
         # Note that this is not a schema field, it's intended to be configured
         # on a class, or rarely, through direct intervention on a particular
         # subscription.
-        u'An integer giving approximately the number of delivery attempts this object will store.'
+        u'An integer giving approximately the number of delivery attempts this object will store. '
+        u'This is also used to deactivate the subscription when this many attempts in a row have '
+        u'failed.'
     )
 
 class ILimitedApplicabilityPreconditionFailureWebhookSubscription(IWebhookSubscription):
@@ -608,6 +612,7 @@ class IWebhookSubscriptionApplicabilityPreconditionFailureLimitReached(IObjectEv
     )
 
 
+@implementer(IWebhookSubscriptionApplicabilityPreconditionFailureLimitReached)
 class WebhookSubscriptionApplicabilityPreconditionFailureLimitReached(ObjectEvent):
 
     def __init__(self, subscription, failures):

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -539,6 +539,8 @@ class IWebhookSubscription(IContainerNamesContainer):
         This does not take into account whether this subscription is
         active or not, but does take into account the permission and principal
         declared for the subscription as well as the type/interface.
+
+        This is a query method that does not mutate this object.
         """
 
     def createDeliveryAttempt(payload_data):
@@ -561,7 +563,35 @@ class IWebhookSubscription(IContainerNamesContainer):
         readonly=True,
     )
 
-class IWebhookSubscriptionManager(IContainerNamesContainer):
+
+class IWebhookSubscriptionRegistry(Interface):
+
+    def activeSubscriptions(data, event):
+        """
+        Find active subscriptions for the *data* and the *event*.
+
+        This is a simple query method and does not result in any status changes
+        or signal an intent to deliver.
+
+        :return: A sequence of subscriptions.
+        """
+
+    def subscriptionsToDeliver(data, event):
+        """
+        Find subscriptions that are both active and applicable for the
+        *data* and the *event*.
+
+        Subscriptions that are active, but not applicable, due to
+        circumstances unrelated to the data and event (for example,
+        the permission is not available, or the principal or dialect
+        cannot be found) may be removed from the active set of subscriptions
+        for future calls to this method and :meth:`activeSubscriptions`.
+
+        :return: A sequence of subscriptions.
+        """
+
+class IWebhookSubscriptionManager(IWebhookSubscriptionRegistry,
+                                  IContainerNamesContainer):
     """
     A utility that manages subscriptions.
 

--- a/src/nti/webhooks/subscribers.py
+++ b/src/nti/webhooks/subscribers.py
@@ -90,6 +90,16 @@ def dispatch_webhook_event(data, event):
         - Determines if any of those actually apply to the *data*, and
           if so, joins the transaction to prepare for sending them.
 
+    .. important::
+
+       Checking whether a subscription is :term:`applicable`
+       depends on the security policy in use. Most security policies
+       inspect the object's lineage or location (walking up the ``__parent__`` tree)
+       so it's important to use this subscriber only for events where that part
+       of the object is intact. For example, it does not usually apply for
+       :class:`~.ObjectCreatedEvent`, but does for :class:`~.ObjectAddedEvent`.
+       See :doc:`configuration` for more.
+
     .. caution::
 
         This function assumes the global, thread-local transaction manager. If any

--- a/src/nti/webhooks/subscribers.py
+++ b/src/nti/webhooks/subscribers.py
@@ -15,7 +15,6 @@ __all__ = ()
 import transaction
 from zope import component
 from zope import interface
-from zope.interface import providedBy
 from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.securitypolicy.interfaces import IPrincipalPermissionManager
 
@@ -24,18 +23,15 @@ from nti.webhooks.interfaces import IWebhookSubscription
 from nti.webhooks.interfaces import IWebhookSubscriptionSecuritySetter
 from nti.webhooks.datamanager import WebhookDataManager
 
-def find_active_subscriptions_for(data, event):
-    """
-    Part of :func:`dispatch_webhook_event`, broken out for testing.
 
-    Internal use only.
+def _find_subscription_managers(data):
+    """
+    Iterable across subscription managers.
     """
     # TODO: What's the practical difference using ``getUtilitiesFor`` and manually walking
     # through the tree using ``getNextUtility``? The first makes a single call to the adapter
     # registry and uses its own ``.ro`` to walk up and find utilities. The second uses
     # the ``__bases__`` of the site manager itself to walk up and find only the next utility.
-    subscriptions = []
-    provided = [providedBy(data), providedBy(event)]
     seen_managers = set()
     for context in None, data:
         # A context of None means to use the current site manager.
@@ -45,13 +41,36 @@ def find_active_subscriptions_for(data, event):
                 # De-dup.
                 continue
             seen_managers.add(sub_manager)
-            local_subscriptions = sub_manager.registry.adapters.subscriptions(provided, None)
-            subscriptions.extend(local_subscriptions)
+            yield sub_manager
+
+
+def find_applicable_subscriptions_for(data, event):
+    """
+    Part of :func:`dispatch_webhook_event`, broken out for testing.
+
+    Internal use only.
+    """
+    subscriptions = []
+    for sub_manager in _find_subscription_managers(data):
+        subscriptions.extend(sub_manager.subscriptionsToDeliver(data, event))
     return subscriptions
+
+
+def find_active_subscriptions_for(data, event):
+    """
+    Part of :func:`dispatch_webhook_event`, broken out for testing.
+
+    Internal use only.
+    """
+    subscriptions = []
+    for sub_manager in _find_subscription_managers(data):
+        subscriptions.extend(sub_manager.activeSubscriptions(data, event))
+    return subscriptions
+
 
 def dispatch_webhook_event(data, event):
     """
-    A subcriber installed to dispatch events to webhook subscriptions.
+    A subscriber installed to dispatch events to webhook subscriptions.
 
     This is usually registered in the global registry by loading
     ``subscribers.zcml`` or ``subscribers_promiscuous.zcml``, but the
@@ -77,9 +96,8 @@ def dispatch_webhook_event(data, event):
         objects belong to ZODB connections that are using a different transaction
         manager, this won't work.
     """
-    # TODO: I think we could actually find a differen transaction manager if we needed to.
-    subscriptions = find_active_subscriptions_for(data, event)
-    subscriptions = [sub for sub in subscriptions if sub.isApplicable(data)]
+    # TODO: I think we could actually find a different transaction manager if we needed to.
+    subscriptions = find_applicable_subscriptions_for(data, event)
     if subscriptions:
         # TODO: Choosing which datamanager resource to use might
         # be a good extension point.

--- a/src/nti/webhooks/testing.py
+++ b/src/nti/webhooks/testing.py
@@ -21,7 +21,7 @@ from nti.testing.zodb import ZODBLayer
 
 from nti.webhooks.delivery_manager import IExecutorService
 from nti.webhooks.interfaces import IWebhookDestinationValidator
-
+from nti.webhooks.interfaces import IWebhookDeliveryManager
 
 class UsingMocks(object):
     """
@@ -195,3 +195,11 @@ def target_validation_fails():
         gsm.unregisterUtility(new_validator)
         if old_validator is not None:
             gsm.registerUtility(old_validator)
+
+def wait_for_deliveries():
+    """
+    Queries the current :class:`nti.webhooks.interfaces.IWebhookDeliveryManager`
+    and asks it to wait for all pending deliveries.
+    """
+    delivery_man = component.getUtility(IWebhookDeliveryManager)
+    delivery_man.waitForPendingDeliveries()

--- a/src/nti/webhooks/zcml.py
+++ b/src/nti/webhooks/zcml.py
@@ -66,6 +66,7 @@ def _static_subscription_action(subscription_kwargs):
     getGlobalSubscriptionManager().createSubscription(**subscription_kwargs)
 
 def static_subscription(context, **kwargs):
+    # type: (zope.configuration.config.ConfigurationMachine, dict) -> None
     to = kwargs.pop('to')
     for_ = kwargs.pop('for_', None) or IStaticSubscriptionDirective['for_'].default
     when = kwargs.pop('when', None) or IStaticSubscriptionDirective['when'].default
@@ -88,5 +89,8 @@ def static_subscription(context, **kwargs):
         # as you want.
         discriminator=None,
         callable=_static_subscription_action,
-        args=(subscription_kwargs,)
+        args=(subscription_kwargs,),
+        # Try to execute towards the end so any validation that needs
+        # previous directives, like permission lookup, can work.
+        order=9999
     )


### PR DESCRIPTION
Both should result in de-activating the subscription.

Failed deliveries are there; applicability tests are close.