### PR TITLE
Add persistent ZCML-based subscriptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,12 +12,13 @@
    :target: https://ntiwebhooks.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-.. sphinx-include-begin
 
 This package provides the infrastructure and delivery mechanisms for a
 server to support webhook delivery. For complete details and the
 changelog, see the `documentation
 <http://ntiwebhooks.readthedocs.io/>`_.
+
+.. sphinx-include-begin-prelude
 
 Webhooks
 ========
@@ -102,6 +103,8 @@ includes everything the receiver needs for that and doesn't do
 anything like add an X-NTI-EventType header or add something to the
 JSON body. It can be a URL parameter or a whole different URL, doesn't
 matter.
+
+.. sphinx-include-after-prelude
 
 Out Of Scope
 ============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,6 +372,7 @@ intersphinx_mapping = {
     'https://zopelifecycleevent.readthedocs.io/en/latest/': None,
     'https://zopelocation.readthedocs.io/en/latest/': None,
     'https://zopeprincipalregistry.readthedocs.io/en/latest/': None,
+    'https://zopeprocesslifetime.readthedocs.io/en/latest/': None,
     'https://zopesecurity.readthedocs.io/en/latest/': None,
     'https://zopesite.readthedocs.io/en/latest/': None,
     'https://zopetraversing.readthedocs.io/en/latest/': None,

--- a/docs/delivery_helper.py
+++ b/docs/delivery_helper.py
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 @time_monotonically_increases
-def deliver_some(how_many=1, note=None, grants=None):
+def deliver_some(how_many=1, note=None, grants=None, event='created'):
     for _ in range(how_many):
         tx = transaction.begin()
         if note:
@@ -28,5 +28,6 @@ def deliver_some(how_many=1, note=None, grants=None):
             prin_perm = IPrincipalPermissionManager(content)
             for principal_id, perm_id in grants.items():
                 prin_perm.grantPermissionToPrincipal(perm_id, principal_id)
-        lifecycleevent.created(content)
+        sender = getattr(lifecycleevent, event)
+        sender(content)
         transaction.commit()

--- a/docs/dynamic.rst
+++ b/docs/dynamic.rst
@@ -123,18 +123,16 @@ be opening and closing multiple transactions).
    >>> office = department['OUN'] = Office()
    >>> department_bob = department['employees']['Bob'] = Employee()
    >>> office_bob = office['employees']['Bob'] = Employee()
-   >>> print_tree(root_folder)
-        <ISite,IRootFolder>: <zope.site.folder.Folder object ...>
-            <ISite,IMainApplicationFolder>: NOAA ...
-                ++etc++hostsites ...
-                <ISite>: NWS ...
-                    <ISite>: OUN ...
-                        employees ...
-                            Bob ...
-                            ...
-                    employees ...
-                        Bob ...
-                            ...
+   >>> print_tree(root_folder, depth=0, details=())
+   <ISite,IRootFolder>: <zope.site.folder.Folder object...>
+        <ISite,IMainApplicationFolder>: NOAA
+            ++etc++hostsites
+            <ISite>: NWS
+                <ISite>: OUN
+                    employees
+                        Bob => <Employee Bob 1>
+                employees
+                    Bob => <Employee Bob 0>
    >>> office_bob_path = ztapi.getPath(office_bob)
    >>> print(office_bob_path)
    /NOAA/NWS/OUN/employees/Bob
@@ -175,10 +173,10 @@ back to the subscription, and its manager:
 
    >>> path = ztapi.getPath(subscription)
    >>> print(path)
-   /NOAA/NWS/OUN/++etc++site/WebhookSubscriptionManager/PersistentSubscription
+   /NOAA/NWS/OUN/++etc++site/default/WebhookSubscriptionManager/PersistentSubscription
    >>> ztapi.traverse(root_folder, path) is subscription
    True
-   >>> ztapi.traverse(root_folder, '/NOAA/NWS/OUN/++etc++site/WebhookSubscriptionManager')
+   >>> ztapi.traverse(root_folder, '/NOAA/NWS/OUN/++etc++site/default/WebhookSubscriptionManager')
    <....PersistentWebhookSubscriptionManager object at 0x...>
 
 The ``for`` Was Inferred

--- a/docs/employees.py
+++ b/docs/employees.py
@@ -16,5 +16,20 @@ class Office(Employees):
     pass
 
 class Employee(Contained, Persistent):
+    COUNTER = 0
+
+    def __init__(self):
+        self.__counter__ = self.COUNTER
+        Employee.COUNTER += 1
+
     def toExternalObject(self, **kwargs):
         return self.__name__
+
+    def __repr__(self):
+        return "<Employee %s %d>" % (
+            self.__name__,
+            self.__counter__,
+        )
+
+from zope.testing import cleanup
+cleanup.addCleanUp(lambda: setattr(Employee, 'COUNTER', 0))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,14 +3,26 @@
  nti.webhooks
 ==============
 
-Contents:
+.. contents::
+   :local:
+
+.. include:: ../README.rst
+   :start-after: sphinx-include-begin-prelude
+   :end-before: sphinx-include-after-prelude
+
+.. note:: See the :doc:`glossary` for common terminology.
+
+Documentation
+=============
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
+   scope
    glossary
    configuration
    static
+   static-persistent
    security
    delivery_attempts
    subscription_security
@@ -21,10 +33,6 @@ Contents:
    changelog
 
 
-.. note:: See the :doc:`glossary` for common terminology.
-
-.. include:: ../README.rst
-   :start-after: sphinx-include-begin
 
 TODO
 ====

--- a/docs/scope.rst
+++ b/docs/scope.rst
@@ -1,0 +1,7 @@
+=======
+ Scope
+=======
+
+
+.. include:: ../README.rst
+   :start-after: sphinx-include-after-prelude

--- a/docs/static-persistent.rst
+++ b/docs/static-persistent.rst
@@ -7,6 +7,9 @@
 .. testsetup::
 
    from zope.testing import cleanup
+   # zope.session is not strict-iro friendly at this time
+   from zope.interface import ro
+   ro.C3.STRICT_IRO = False
 
 A step between :doc:`global, static, transient subscriptions
 <static>` and :doc:`local, runtime-installed history-free
@@ -20,7 +23,128 @@ The ZCML directive is very similar to :class:`IStaticSubscriptionDirective`.
 .. autointerface:: IStaticPersistentSubscriptionDirective
 
 
+In order to use this directive, there must be at least one site manager
+configured in the main ZODB database. This can be done in a variety of
+ways, but one of the easiest is to use `zope.app.appsetup
+<https://pypi.org/project/zope.app.appsetup/>`_. We do this by just
+including its configuration (along with a few standard packages).
+
+.. doctest::
+
+   >>> from zope.configuration import xmlconfig
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
+   ...   <include package="zope.app.appsetup" />
+   ... </configure>
+   ... """)
+
+Wait, didn't we forget someting? Where's the database? Well, we
+haven't established one yet. Let's do that.
+
+.. doctest::
+
+   >>> from nti.site.testing import print_tree
+   >>> from ZODB import DB, DemoStorage
+   >>> db = DB(DemoStorage.DemoStorage())
+   >>> conn = db.open()
+   >>> root = conn.root()
+   >>> print_tree(root)
+        <Connection Root Dictionary> ... <class 'persistent.mapping.PersistentMapping'>
+   >>> conn.close()
+
+Of course, creating the database by itself does nothing. Like most
+things, ``zope.app.appsetup`` is based on events. Including its
+configuration just established the event handlers. In this case, the
+event that needs to be sent is
+:class:`zope.processlifetime.DatabaseOpened`.
+
+.. doctest::
+
+   >>> from zope.processlifetime import DatabaseOpened
+   >>> from zope.event import notify
+   >>> notify(DatabaseOpened(db))
+   >>> def show_trees():
+   ...     conn = db.open()
+   ...     root = conn.root()
+   ...     print_tree(root)
+   ...     app = conn.root.Application
+   ...     site_man = app.getSiteManager()
+   ...     print_tree(site_man)
+   ...     conn.close()
+   >>> show_trees()
+        <Connection Root Dictionary> ... <class 'persistent.mapping.PersistentMapping'>
+            <ISite,IRootFolder>: Application ... <class 'zope.site.folder.Folder'>
+         ++etc++site ... <class 'zope.site.site.LocalSiteManager'>
+             default ... <class 'zope.site.site.SiteManagementFolder'>
+                 CookieClientIdManager ... <class 'zope.session.http.CookieClientIdManager'>
+                     <zope.session.http.CookieClientIdManager ...>
+                 PersistentSessionDataContainer ... <class 'zope.session.session.PersistentSessionDataContainer'>
+                 RootErrorReportingUtility ... <class 'zope.error.error.RootErrorReportingUtility'>
+                     <zope.error.error.RootErrorReportingUtility ...>
+
+The event handler here first made sure there was a site (called
+"Application") with a few standard utilities, and then notified
+:class:`zope.processlifetime.DatabaseOpenedWithRoot`. That event is
+used by `zope.generations
+<https://pypi.org/project/zope.generations/>`_ to perform further
+installation activities, as wall as upgrades and migrations.
+
+And finally, then, that's here this package comes in. It connects with
+``zope.generations`` to manage adding, and removing, these persistent
+local subscriptions.
+
+Adding A Subscription
+=====================
+
+Let's use the ZCML to add a subscription. The unique required
+parameter here is ``site_path``, which must be the traversable path to
+a ``ISite`` into which the persistent subscription manager will be
+installed.
+
+.. doctest::
+
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="nti.webhooks" file="meta.zcml" />
+   ...   <webhooks:persistentSubscription
+   ...             site_path="/Application"
+   ...             to="https://example.com" />
+   ... </configure>
+   ... """)
+
+
+This hasn't actually done anything yet, it's merely collected the necessary information.
+
+.. doctest::
+   >>> show_trees()
+        <Connection Root Dictionary> ... <class 'persistent.mapping.PersistentMapping'>
+            <ISite,IRootFolder>: Application ... <class 'zope.site.folder.Folder'>
+         ++etc++site ... <class 'zope.site.site.LocalSiteManager'>
+             default ... <class 'zope.site.site.SiteManagementFolder'>
+                 CookieClientIdManager ... <class 'zope.session.http.CookieClientIdManager'>
+                     <zope.session.http.CookieClientIdManager ...>
+                 PersistentSessionDataContainer ... <class 'zope.session.session.PersistentSessionDataContainer'>
+                 RootErrorReportingUtility ... <class 'zope.error.error.RootErrorReportingUtility'>
+                     <zope.error.error.RootErrorReportingUtility ...>
+
+Once again, to take action we need to notify the event.
+
+.. doctest::
+
+   >>> notify(DatabaseOpened(db))
+   >>> show_trees()
+
 .. testcleanup::
 
    from zope.testing import cleanup
    cleanup.cleanUp()
+   ro.C3.STRICT_IRO = ro._ClassBoolFromEnv()
+   db.close()

--- a/docs/static-persistent.rst
+++ b/docs/static-persistent.rst
@@ -1,0 +1,14 @@
+====================================================
+ Configured Local, Persistent Webhook Subscriptions
+====================================================
+
+.. currentmodule:: nti.webhooks.zcml
+
+.. testsetup::
+
+   from zope.testing import cleanup
+
+.. testcleanup::
+
+   from zope.testing import cleanup
+   cleanup.cleanUp()

--- a/docs/static-persistent.rst
+++ b/docs/static-persistent.rst
@@ -8,6 +8,18 @@
 
    from zope.testing import cleanup
 
+A step between :doc:`global, static, transient subscriptions
+<static>` and :doc:`local, runtime-installed history-free
+subscriptions <dynamic>` are the subscriptions described in this
+document: they are statically configured using ZCML, but instead of
+being global, they are located in the database (in a site manager) and
+store history.
+
+The ZCML directive is very similar to :class:`IStaticSubscriptionDirective`.
+
+.. autointerface:: IStaticPersistentSubscriptionDirective
+
+
 .. testcleanup::
 
    from zope.testing import cleanup

--- a/docs/static-persistent.rst
+++ b/docs/static-persistent.rst
@@ -10,6 +10,10 @@
    # zope.session is not strict-iro friendly at this time
    from zope.interface import ro
    ro.C3.STRICT_IRO = False
+   # We don't establish the securitypolicy, so zope.app.appsetup
+   # complains by logging. Silence that.
+   import logging
+   logging.getLogger('zope.app.appsetup').setLevel(logging.CRITICAL)
 
 A step between :doc:`global, static, transient subscriptions
 <static>` and :doc:`local, runtime-installed history-free
@@ -53,8 +57,8 @@ haven't established one yet. Let's do that.
    >>> db = DB(DemoStorage.DemoStorage())
    >>> conn = db.open()
    >>> root = conn.root()
-   >>> print_tree(root)
-        <Connection Root Dictionary> ... <class 'persistent.mapping.PersistentMapping'>
+   >>> print_tree(root, depth=0, details=('len',))
+   <Connection Root Dictionary> len=0
    >>> conn.close()
 
 Of course, creating the database by itself does nothing. Like most
@@ -71,21 +75,22 @@ event that needs to be sent is
    >>> def show_trees():
    ...     conn = db.open()
    ...     root = conn.root()
-   ...     print_tree(root)
-   ...     app = conn.root.Application
-   ...     site_man = app.getSiteManager()
-   ...     print_tree(site_man)
+   ...     print_tree(root,
+   ...                depth=0,
+   ...                show_unknown=type,
+   ...                details=('len', 'siteManager'),
+   ...                basic_indent='  ',
+   ...                known_types=(int, tuple,))
    ...     conn.close()
    >>> show_trees()
-        <Connection Root Dictionary> ... <class 'persistent.mapping.PersistentMapping'>
-            <ISite,IRootFolder>: Application ... <class 'zope.site.folder.Folder'>
-         ++etc++site ... <class 'zope.site.site.LocalSiteManager'>
-             default ... <class 'zope.site.site.SiteManagementFolder'>
-                 CookieClientIdManager ... <class 'zope.session.http.CookieClientIdManager'>
-                     <zope.session.http.CookieClientIdManager ...>
-                 PersistentSessionDataContainer ... <class 'zope.session.session.PersistentSessionDataContainer'>
-                 RootErrorReportingUtility ... <class 'zope.error.error.RootErrorReportingUtility'>
-                     <zope.error.error.RootErrorReportingUtility ...>
+   <Connection Root Dictionary> len=1
+      <ISite,IRootFolder>: Application len=0
+        <Site Manager> name=++etc++site len=1
+          default len=3
+            CookieClientIdManager => <class 'zope.session.http.CookieClientIdManager'>
+            PersistentSessionDataContainer len=0
+            RootErrorReportingUtility => <class 'zope.error.error.RootErrorReportingUtility'>
+
 
 The event handler here first made sure there was a site (called
 "Application") with a few standard utilities, and then notified
@@ -98,6 +103,7 @@ And finally, then, that's here this package comes in. It connects with
 ``zope.generations`` to manage adding, and removing, these persistent
 local subscriptions.
 
+
 Adding A Subscription
 =====================
 
@@ -106,41 +112,101 @@ parameter here is ``site_path``, which must be the traversable path to
 a ``ISite`` into which the persistent subscription manager will be
 installed.
 
+.. important::
+
+   To use ``zope.generations``, and consequently this package's
+   integration with it, you must either specifically include the
+   ``subscriber.zcml`` from that package (which evolves to the minimum
+   required generation), or manually register the alternate handler
+   that evolves to the maximum available generation.
+
+   If you manually register the alternate subscriber that simply
+   checks whether the generation is sufficient, you will not be able
+   to make future changes to your persistent webhook subscriptions.
+
 .. doctest::
 
-   >>> conf_context = xmlconfig.string("""
+   >>> zcml_string = """
    ... <configure
    ...     xmlns="http://namespaces.zope.org/zope"
    ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
    ...     >
    ...   <include package="nti.webhooks" file="meta.zcml" />
+   ...   <include package="zope.generations" file="subscriber.zcml" />
    ...   <webhooks:persistentSubscription
    ...             site_path="/Application"
+   ...             for="zope.container.interfaces.IContentContainer"
+   ...             when="zope.lifecycleevent.interfaces.IObjectCreatedEvent"
    ...             to="https://example.com" />
    ... </configure>
-   ... """)
+   ... """
+   >>> _ = xmlconfig.string(zcml_string)
 
 
-This hasn't actually done anything yet, it's merely collected the necessary information.
+Once again, this hasn't done anything to the database yet, it's merely
+collected the necessary information.
 
 .. doctest::
-   >>> show_trees()
-        <Connection Root Dictionary> ... <class 'persistent.mapping.PersistentMapping'>
-            <ISite,IRootFolder>: Application ... <class 'zope.site.folder.Folder'>
-         ++etc++site ... <class 'zope.site.site.LocalSiteManager'>
-             default ... <class 'zope.site.site.SiteManagementFolder'>
-                 CookieClientIdManager ... <class 'zope.session.http.CookieClientIdManager'>
-                     <zope.session.http.CookieClientIdManager ...>
-                 PersistentSessionDataContainer ... <class 'zope.session.session.PersistentSessionDataContainer'>
-                 RootErrorReportingUtility ... <class 'zope.error.error.RootErrorReportingUtility'>
-                     <zope.error.error.RootErrorReportingUtility ...>
 
-Once again, to take action we need to notify the event.
+   >>> show_trees()
+   <Connection Root Dictionary> len=1
+      <ISite,IRootFolder>: Application len=0
+        <Site Manager> name=++etc++site len=1
+          default len=3
+            CookieClientIdManager => <class 'zope.session.http.CookieClientIdManager'>
+            PersistentSessionDataContainer len=0
+            RootErrorReportingUtility => <class 'zope.error.error.RootErrorReportingUtility'>
+
+To take action we need to notify the event. When we do, we
+see that a subscription manager and subscription have been created in
+the defined location. Also, some bookkeeping information has been
+added to the root of the database.
 
 .. doctest::
 
    >>> notify(DatabaseOpened(db))
    >>> show_trees()
+   <Connection Root Dictionary> len=3
+      <ISite,IRootFolder>: Application len=0
+        <Site Manager> name=++etc++site len=1
+          default len=4
+            CookieClientIdManager => <class 'zope.session.http.CookieClientIdManager'>
+            PersistentSessionDataContainer len=0
+            RootErrorReportingUtility => <class 'zope.error.error.RootErrorReportingUtility'>
+            WebhookSubscriptionManager len=1
+              PersistentSubscription len=0
+      nti.webhooks.generations.PersistentWebhookSchemaManager len=2 => ((('/Application',...
+      zope.generations len=1
+        zzzz-nti.webhooks => 1
+
+The bookkeeping information is used to make sure that subscriptions in
+the database stay in sync with what's in the ZCML. If we execute the
+same ZCML again and re-notify the database opening, nothing in the database changes.
+
+.. doctest::
+
+   >>> _ = xmlconfig.string(zcml_string)
+   >>> notify(DatabaseOpened(db))
+   >>> show_trees()
+   <Connection Root Dictionary> len=3
+      <ISite,IRootFolder>: Application len=0
+        <Site Manager> name=++etc++site len=1
+          default len=4
+            CookieClientIdManager => <class 'zope.session.http.CookieClientIdManager'>
+            PersistentSessionDataContainer len=0
+            RootErrorReportingUtility => <class 'zope.error.error.RootErrorReportingUtility'>
+            WebhookSubscriptionManager len=1
+              PersistentSubscription len=0
+      nti.webhooks.generations.PersistentWebhookSchemaManager len=2 => ((('/Application',...
+      zope.generations len=1
+        zzzz-nti.webhooks => 1
+
+
+.. todo:: Deliver to the subscription, both with and without the site active.
+.. todo:: Add a new subscription, verify the old subscription is unchanged.
+.. todo:: Mutate one of the definitions, verify that a new subscription is created while the old
+          one is deactivated.
+.. todo:: Likewise for removing a definition.
 
 .. testcleanup::
 

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -1,6 +1,6 @@
-=========================================================
- Configured Global, Non-Persistent Webhook Subscriptions
-=========================================================
+====================================================
+ Configured Global, Transient Webhook Subscriptions
+====================================================
 
 .. currentmodule:: nti.webhooks.zcml
 
@@ -11,11 +11,20 @@
 
 The simplest type of webhook :term:`subscription` is one that is
 configured statically, typically at application startup time, and
-stores no persistent history. This package provides ZCML directives to
-facilitate this. The directives can either be used globally, creating
-subscriptions that are valid across the entire application, or can be
-scoped to a smaller portion of the application using
-`z3c.baseregistry`_.
+stores no persistent history (with the facilities provided by this
+package; applications may store their own history, perhaps by
+listening for :doc:`delivery events <events>`).
+
+This is useful for a number of scenarios, including:
+
+- Development;
+- Integration testing;
+- Fire-and-forget delivery of frequent events;
+- Simple applications.
+
+This package provides ZCML directives to facilitate this. The
+directives can either be used globally, creating subscriptions that
+are valid across the entire application.
 
 .. autointerface:: IStaticSubscriptionDirective
 

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -1,6 +1,6 @@
-==============================
- Static Webhook Subscriptions
-==============================
+=========================================================
+ Configured Global, Non-Persistent Webhook Subscriptions
+=========================================================
 
 .. currentmodule:: nti.webhooks.zcml
 
@@ -10,11 +10,12 @@
 
 
 The simplest type of webhook :term:`subscription` is one that is
-configured statically, typically at application startup time. This
-package provides ZCML directives to facilitate this. The directives
-can either be used globally, creating subscriptions that are valid
-across the entire application, or can be scoped to a smaller portion
-of the application using `z3c.baseregistry`_.
+configured statically, typically at application startup time, and
+stores no persistent history. This package provides ZCML directives to
+facilitate this. The directives can either be used globally, creating
+subscriptions that are valid across the entire application, or can be
+scoped to a smaller portion of the application using
+`z3c.baseregistry`_.
 
 .. autointerface:: IStaticSubscriptionDirective
 
@@ -256,6 +257,8 @@ But it does record a failed attempt in the subscription:
 
 Inactive Subscriptions
 ======================
+
+.. XXX: This doesn't really belong here.
 
 Subscriptions can be deactivated (made :term:`inactive`) by asking the
 manager to do this. The subscription manager is always the subscription's parent,

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ TESTS_REQUIRE = [
     'zope.securitypolicy', # ZCML directives for granting/denying
     # Easy mocking of ``requests``.
     'responses',
+    # Simpler site setup than nti.site
+    'zope.app.appsetup',
 ]
 
 def _read(fname):
@@ -69,6 +71,7 @@ setup(
         'zope.componentvocabulary',
         'zope.vocabularyregistry',
         'zope.securitypolicy', # IPrincipalPermissionManager
+        'zope.generations', # schema installers
         'zope.site',
         'nti.site',
         'nti.zodb',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'zope.securitypolicy', # IPrincipalPermissionManager
         'zope.generations', # schema installers
         'zope.site',
-        'nti.site',
+        'nti.site >= 2.2.0',
         'nti.zodb',
         'nti.externalization >= 2.0.0', # Consistent interface resolution order
         'nti.schema',

--- a/src/nti/webhooks/api.py
+++ b/src/nti/webhooks/api.py
@@ -10,6 +10,8 @@ from __future__ import print_function
 from zope.interface import providedBy
 from zope.component import getSiteManager
 from zope.container.interfaces import IContainer
+from zope.traversing import api as ztapi
+from zope.location.interfaces import LocationError
 
 from nti.webhooks.interfaces import IWebhookSubscription
 from nti.webhooks.interfaces import IWebhookSubscriptionManager
@@ -51,18 +53,39 @@ def subscribe_to_resource(resource, to, for_=None,
             for_ = for_()
 
     site_manager = getSiteManager(resource)
+    return subscribe_in_site_manager(site_manager,
+                                     to=to, for_=for_, when=when,
+                                     dialect_id=dialect_id,
+                                     owner_id=owner_id,
+                                     permission_id=permission_id)
+
+def subscribe_in_site_manager(site_manager, **subscription_kwargs):
+    """
+    Produce and return a persistent ``IWebhookSubscription`` in the
+    given site manager.
+
+    The *subscription_kwargs* are as for
+    :meth:`nti.webhooks.interfaces.IWebhookSubscriptionManager.createSubscription`.
+    No defaults are applied here.
+    """
     sub_name = 'WebhookSubscriptionManager'
     if IContainer.providedBy(site_manager):
-        sub_manager = site_manager.get(sub_name) # pylint:disable=no-member
+        # The preferred location for utilities is in the 'default'
+        # child: A SiteManagementFolder. But not every site manager
+        # is guaranteed to have one of those, sadly.
+        # The best way to get there, dealing with unicode, etc, is through
+        # traversal.
+        try:
+            parent = ztapi.traverse(site_manager, 'default')
+        except LocationError:
+            parent = site_manager
+        sub_manager = parent.get(sub_name) # pylint:disable=no-member
         if sub_manager is None:
-            sub_manager = site_manager[sub_name] = PersistentWebhookSubscriptionManager()
+            sub_manager = parent[sub_name] = PersistentWebhookSubscriptionManager()
             site_manager.registerUtility(sub_manager, IWebhookSubscriptionManager)
     else:
         # Perhaps we should fail?
         sub_manager = site_manager.getUtility(IWebhookSubscriptionManager)
 
-    subscription = sub_manager.createSubscription(to=to, for_=for_, when=when,
-                                                  dialect_id=dialect_id,
-                                                  owner_id=owner_id,
-                                                  permission_id=permission_id)
+    subscription = sub_manager.createSubscription(**subscription_kwargs)
     return subscription

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -29,7 +29,12 @@
     <!-- Traversing arbitrary objects, including many traversal adapters -->
     <include package="zope.traversing" />
 
-    <!-- Run our schema installer on IDatabaseOpenedWithRoote -->
+    <!-- Run our schema installer on IDatabaseOpenedWithRoot -->
+    <!--
+        Except, no, this file alone doesn't do that. You must manually include
+        the 'subscribers.zcml' file, or register a specific evolution
+        handler. The correct choice is up to the application.
+    -->
     <include package="zope.generations" />
 
     <!-- Basic externalization support -->
@@ -64,8 +69,10 @@
     <!-- The default dialect -->
     <utility factory=".dialect.DefaultWebhookDialect" />
 
-    <!-- Persistent subscriptions from ZCML -->
-    <utility factory=".generations.PersistentWebhookSchemaManager" />
+    <!-- Persistent subscriptions from ZCML. -->
+    <!-- Try to run at the end using a low-sorting name. -->
+    <utility factory=".generations.PersistentWebhookSchemaManager"
+             name="zzzz-nti.webhooks" />
     <subscriber handler=".generations.update_schema_manager" />
 
     <!-- Global event dispatchers are configured in subscribers.zcml -->

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -9,6 +9,7 @@
     <include package="." file="meta.zcml" />
 
     <include package="zope.component" />
+    <include package="zope.location" />
     <include package="zope.container" />
     <!-- make vocabularies go through zope.component -->
     <include package="zope.vocabularyregistry" />
@@ -24,6 +25,12 @@
 
     <!-- Annotations, used for security. -->
     <include package="zope.annotation" />
+
+    <!-- Traversing arbitrary objects, including many traversal adapters -->
+    <include package="zope.traversing" />
+
+    <!-- Run our schema installer on IDatabaseOpenedWithRoote -->
+    <include package="zope.generations" />
 
     <!-- Basic externalization support -->
     <include package="nti.externalization" />
@@ -56,6 +63,10 @@
 
     <!-- The default dialect -->
     <utility factory=".dialect.DefaultWebhookDialect" />
+
+    <!-- Persistent subscriptions from ZCML -->
+    <utility factory=".generations.PersistentWebhookSchemaManager" />
+    <subscriber handler=".generations.update_schema_manager" />
 
     <!-- Global event dispatchers are configured in subscribers.zcml -->
 

--- a/src/nti/webhooks/generations.py
+++ b/src/nti/webhooks/generations.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+    - We have an IInstallableSchemaManager global utility. ZCML
+      directives register their arguments with this utility.
+
+    - An AfterDatabaseOpened handler reads data from the root of the
+      database about what is currently installed and calculates the
+      difference.
+
+      This information is used to calculate the generation we should use for
+      the schema manager. It needs to handle initial installation of
+      everything as well as adding and removing.
+
+    - When AfterDatabaseOpenedWithRoot fires, our schema manager,
+      which should be named so as to sort near the end, runs and
+      performs required changes, recording what is actually installed
+      in the root of the database.
+
+While this might seem limited to one application or root per database,
+it shouldn't be. The ZCML directives will include the full traversable
+path to a site manager, starting from the root.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function

--- a/src/nti/webhooks/generations.py
+++ b/src/nti/webhooks/generations.py
@@ -24,3 +24,82 @@ path to a site manager, starting from the root.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+
+from transaction import TransactionManager
+
+from zope import interface
+from zope import component
+
+from zope.processlifetime import IDatabaseOpened
+from zope.generations.interfaces import IInstallableSchemaManager
+
+class IPersistentWebhookSchemaManager(IInstallableSchemaManager):
+    """
+    Interface to identify the nti.webhook schema manager.
+    """
+
+    # pylint:disable=no-self-argument
+
+    def addSubscription(site_path, subscription_kwargs):
+        """
+        Record details about a subscription that should exist.
+        """
+
+    def compareSubscriptionsAndComputeGeneration(stored_subscriptions, stored_generation):
+        """
+        Given the subscription information previously stored, determine if
+        we need a new generation.
+        """
+
+
+@interface.implementer(IPersistentWebhookSchemaManager)
+class PersistentWebhookSchemaManager(object):
+
+    key = 'nti.webhooks.generations.PersistentWebhookSchemaManager'
+
+    def __init__(self):
+        self.__generation = None
+        # XXX: When can we calculate the generation we need?
+        # That might have to be in an IDatabaseOpened event
+        self.__subscription_accumulator = []
+
+    def evolve(self, context, generation):
+        raise Exception
+
+    def install(self, context):
+        print("Asked to install")
+        raise Exception
+
+    @property
+    def generation(self):
+        return self.__generation
+
+    minimum_generation = generation
+
+    def addSubscription(self, site_path, subscription_kwargs):
+        self.__subscription_accumulator.append(
+            (site_path, sorted(subscription_kwargs.items()))
+        )
+
+    def compareSubscriptionsAndComputeGeneration(self, stored_subscriptions, stored_generation):
+        # re-sort, just in case sort order changed
+        stored_subscriptions = sorted(stored_subscriptions)
+        if stored_subscriptions == self.__subscription_accumulator:
+            self.__generation = stored_generation
+        else:
+            self.__generation = stored_generation + 1
+        print("Generation", self.__generation)
+
+@component.adapter(IDatabaseOpened)
+def update_schema_manager(event):
+    # Use a local transaction manager to sidestep any issues
+    # with an active transaction or explicit mode.
+    txm = TransactionManager(explicit=True)
+    txm.begin()
+    conn = event.database.open(txm)
+    subscriptions, generation = conn.root().get(PersistentWebhookSchemaManager.key, ([], 0))
+    txm.abort()
+    conn.close()
+
+    schema = component.getUtility(IPersistentWebhookSchemaManager)
+    schema.compareSubscriptionsAndComputeGeneration(subscriptions, generation)

--- a/src/nti/webhooks/meta.zcml
+++ b/src/nti/webhooks/meta.zcml
@@ -10,6 +10,12 @@
             schema="nti.webhooks.zcml.IStaticSubscriptionDirective"
             handler="nti.webhooks.zcml.static_subscription"
             />
+        <meta:directive
+            name="persistentSubscription"
+            schema="nti.webhooks.zcml.IStaticPersistentSubscriptionDirective"
+            handler="nti.webhooks.zcml.persistent_subscription"
+            />
+
     </meta:directives>
 
 </configure>

--- a/src/nti/webhooks/testing.py
+++ b/src/nti/webhooks/testing.py
@@ -61,6 +61,7 @@ class DoctestTransaction(mock_db_trans):
     def finish(self):
         return self.__exit__(None, None, None)
 
+
 class ZODBFixture(object):
     """
     Like :class:`nti.testing.zodb.ZODBLayer`, but
@@ -72,14 +73,14 @@ class ZODBFixture(object):
         for c in reversed(ZODBLayer.__mro__):
             if 'setUp' in c.__dict__:
                 c.__dict__['setUp'].__func__(c)
-
+        cls.db = ZODBLayer.db
 
     @classmethod
     def tearDown(cls):
         for c in ZODBLayer.__mro__:
             if 'tearDown' in c.__dict__:
                 c.__dict__['tearDown'].__func__(c)
-
+        cls.db = None
 
 @interface.implementer(IExecutorService)
 class SequentialExecutorService(object):

--- a/src/nti/webhooks/zcml.py
+++ b/src/nti/webhooks/zcml.py
@@ -145,8 +145,8 @@ def static_subscription(context, **kwargs):
     )
 
 def _persistent_subscription_action(site_path, subscription_kwargs):
-    from .generations import IPersistentWebhookSchemaManager
-    schema = component.getUtility(IPersistentWebhookSchemaManager)
+    from .generations import get_schema_manager
+    schema = get_schema_manager()
     schema.addSubscription(site_path, subscription_kwargs)
 
 def persistent_subscription(context, site_path=None, **kwargs):

--- a/src/nti/webhooks/zcml.py
+++ b/src/nti/webhooks/zcml.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 from zope.configuration.fields import GlobalObject
 from zope.configuration.fields import Text
 
+from zope import component
 from zope.interface import Interface
 
 from zope.security.zcml import Permission
@@ -19,6 +20,21 @@ from nti.webhooks.interfaces import IWebhookSubscription
 from nti.webhooks._schema import ObjectEventInterface
 
 # pylint:disable=inherit-non-class
+
+class Path(Text):
+    """
+    Accepts a single absolute traversable path.
+
+    Unlike :class:`zope.configuration.fields.Path`, this version
+    requires that the path be absolute and uses URL separators.
+    """
+
+    def fromUnicode(self, value):
+        result = super(Path, self).fromUnicode(value)
+        if not result or not result.startswith('/'):
+            raise ValueError() # XXX: This should be something specific.
+        return result
+
 
 class IStaticSubscriptionDirective(Interface):
     """
@@ -80,15 +96,22 @@ class IStaticPersistentSubscriptionDirective(IStaticSubscriptionDirective):
     in executed ZCML. Thus it is very important not to remove ZCML
     directives, or only execute part of the ZCML configuration unless you intend
     for the subscriptions not found in ZCML to be removed.
+
+    All the options are the same as for :class:`IStaticSubscriptionDirective`,
+    with the addition of the required ``site_path``.
     """
 
-    path = Text() # XXX: Need a Path field; the one from zope.configuration means a file path.
+    site_path = Path(
+        title=u'The path to traverse to the site',
+        description=u"A persistent subscription manager will be installed in this site.",
+        required=True,
+    )
+    # XXX: Active/inactive. Should be able to keep one without losing the history.
 
 def _static_subscription_action(subscription_kwargs):
     getGlobalSubscriptionManager().createSubscription(**subscription_kwargs)
 
-def static_subscription(context, **kwargs):
-    # type: (zope.configuration.config.ConfigurationMachine, dict) -> None
+def _check_sub_kwargs(kwargs):
     to = kwargs.pop('to')
     for_ = kwargs.pop('for_', None) or IStaticSubscriptionDirective['for_'].default
     when = kwargs.pop('when', None) or IStaticSubscriptionDirective['when'].default
@@ -105,7 +128,11 @@ def static_subscription(context, **kwargs):
                                owner_id=owner,
                                permission_id=permission,
                                dialect_id=dialect)
+    return subscription_kwargs
 
+def static_subscription(context, **kwargs):
+    # type: (zope.configuration.config.ConfigurationMachine, dict) -> None
+    subscription_kwargs = _check_sub_kwargs(kwargs)
     context.action(
         # No conflicts. You can register as many identical hooks
         # as you want.
@@ -115,4 +142,22 @@ def static_subscription(context, **kwargs):
         # Try to execute towards the end so any validation that needs
         # previous directives, like permission lookup, can work.
         order=9999
+    )
+
+def _persistent_subscription_action(site_path, subscription_kwargs):
+    from .generations import IPersistentWebhookSchemaManager
+    schema = component.getUtility(IPersistentWebhookSchemaManager)
+    schema.addSubscription(site_path, subscription_kwargs)
+
+def persistent_subscription(context, site_path=None, **kwargs):
+    # We need to add the utility and subscription each time we're invoked
+    # in case of z3c.baseregistry, I think. The discriminators should make sure
+    # there's only one.
+
+    subscription_kwargs = _check_sub_kwargs(kwargs)
+
+    context.action(
+        discriminator=(site_path, tuple(subscription_kwargs.items())),
+        callable=_persistent_subscription_action,
+        args=(site_path, subscription_kwargs),
     )


### PR DESCRIPTION
These don't clash with dynamic subscriptions.

They can be added and removed by adjusting the ZCML and restarting; removing deactivates but doesn't actually remove from the database. Existing matching subscriptions are left alone.