### PR TITLE
Add doctests to zope-testrunner

### DIFF
--- a/docs/customizing_payloads.rst
+++ b/docs/customizing_payloads.rst
@@ -4,12 +4,6 @@
 
 .. currentmodule:: nti.webhooks.dialect
 
-.. testsetup::
-
-   from zope.testing import cleanup
-   from nti.webhooks.testing import UsingMocks
-   using_mocks = UsingMocks("POST", 'https://example.com/some/path', status=200)
-
 
 Once an :term:`active` subscription matches and is :term:`applicable`
 for a certain combination of object and event, eventually it's time to
@@ -52,6 +46,9 @@ the objects defined in ``employees.py``:
    ...             when="zope.lifecycleevent.interfaces.IObjectCreatedEvent" />
    ... </configure>
    ... """)
+   >>> from nti.webhooks.testing import mock_delivery_to
+   >>> mock_delivery_to('https://example.com/some/path')
+
 
 Next, we :term:`trigger` the subscription and wait for it to be delivered.
 
@@ -366,7 +363,7 @@ Lets apply some simple customizations and send again.
 .. doctest::
    :hide:
 
-   >>> using_mocks.add('PUT', 'https://example.com/some/path')
+   >>> mock_delivery_to('https://example.com/some/path', 'PUT')
 
 .. doctest::
 
@@ -441,6 +438,5 @@ We can repeat the above example using just ZCML.
 
 .. testcleanup::
 
-   using_mocks.finish()
    from zope.testing import cleanup
    cleanup.cleanUp()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,8 @@
 Documentation
 =============
 
+.. TESTS: If you add new files with tests here, be sure to update test_docs.py
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/static-persistent.rst
+++ b/docs/static-persistent.rst
@@ -6,19 +6,11 @@
 
 .. testsetup::
 
-   from zope.testing import cleanup
-   # zope.session is not strict-iro friendly at this time
-   from zope.interface import ro
-   ro.C3.STRICT_IRO = False
-   # We don't establish the securitypolicy, so zope.app.appsetup
-   # complains by logging. Silence that.
-   import logging
-   logging.getLogger('zope.app.appsetup').setLevel(logging.CRITICAL)
-   from nti.webhooks.testing import ZODBFixture
-   ZODBFixture.setUp()
+   from nti.webhooks.tests.test_docs import zodbSetUp
+   zodbSetUp()
 
 A step between :doc:`global, static, transient subscriptions
-<static>` and :doc:`local, runtime-installed history-free
+<static>` and :doc:`local, runtime-installed history-preserving
 subscriptions <dynamic>` are the subscriptions described in this
 document: they are statically configured using ZCML, but instead of
 being global, they are located in the database (in a site manager) and
@@ -27,7 +19,7 @@ store history.
 The ZCML directive is very similar to :class:`IStaticSubscriptionDirective`.
 
 .. autointerface:: IStaticPersistentSubscriptionDirective
-
+   :noindex:
 
 In order to use this directive, there must be at least one site manager
 configured in the main ZODB database. This can be done in a variety of
@@ -512,7 +504,5 @@ previously existing deactivated subscription.
 
 .. testcleanup::
 
-   from zope.testing import cleanup
-   cleanup.cleanUp()
-   ro.C3.STRICT_IRO = ro._ClassBoolFromEnv()
-   ZODBFixture.tearDown()
+   from nti.webhooks.tests.test_docs import zodbTearDown
+   zodbTearDown()

--- a/src/nti/webhooks/tests/test_docs.py
+++ b/src/nti/webhooks/tests/test_docs.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the documentation.
+
+Runs in zope.testrunner.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import sys
+import unittest
+import doctest
+from zope.testing import cleanup
+
+docs_dir = '../../../../docs/'
+here_dir = os.path.dirname(os.path.abspath(__file__))
+docs_dir = os.path.abspath(here_dir + '/' + docs_dir)
+
+def setUp(_test=None):
+    cleanup.setUp()
+    if docs_dir not in sys.path:
+        sys.path.insert(0, docs_dir)
+
+def tearDown(_test=None):
+    cleanup.tearDown()
+
+def zodbSetUp(_test=None):
+    setUp(_test)
+    # zope.session is not strict-iro friendly at this time
+    from zope.interface import ro
+    ro.C3.STRICT_IRO = False
+    # We don't establish the securitypolicy, so zope.app.appsetup
+    # complains by logging. Silence that.
+    import logging
+    logging.getLogger('zope.app.appsetup').setLevel(logging.CRITICAL)
+    from nti.webhooks.testing import ZODBFixture
+    ZODBFixture.setUp()
+
+def zodbTearDown(_test=None):
+    from zope.interface import ro
+    from nti.webhooks.testing import ZODBFixture
+    ro.C3.STRICT_IRO = ro._ClassBoolFromEnv()
+    ZODBFixture.tearDown()
+    tearDown(_test)
+
+def test_suite():
+    doctest_flags = (
+        doctest.NORMALIZE_WHITESPACE
+        | doctest.IGNORE_EXCEPTION_DETAIL
+        | doctest.ELLIPSIS
+    )
+
+    def read(abs_path):
+        with open(abs_path, 'r') as f:
+            return f.read()
+
+    def pick_fixture(abs_path):
+        contents = read(abs_path)
+        if 'zodbSetUp' in contents:
+            return {
+                'setUp': zodbSetUp,
+                'tearDown': zodbTearDown
+            }
+        return {
+            'setUp': setUp,
+            'tearDown': tearDown
+        }
+
+    def make_doctest(path_rel_to_docs):
+        if not path_rel_to_docs.endswith('.rst'):
+            path_rel_to_docs = path_rel_to_docs + '.rst'
+        abs_path = os.path.join(docs_dir, path_rel_to_docs)
+        rel_to_here = os.path.relpath(abs_path, here_dir)
+        print("File", path_rel_to_docs, 'here', here_dir, 'abs_path', abs_path)
+        test = doctest.DocFileSuite(
+            rel_to_here,
+            optionflags=doctest_flags,
+            **pick_fixture(abs_path)
+        )
+        return test
+
+    t = make_doctest
+
+    return unittest.TestSuite((
+        t('configuration'),
+        t('static'),
+        t('static-persistent'),
+        t('security'),
+        t('delivery_attempts'),
+        t('subscription_security'),
+        t('customizing_payloads'),
+        t('dynamic'),
+        t('dynamic/customizing_for'),
+        t('events'),
+        t('externalization'),
+    ))

--- a/src/nti/webhooks/tests/test_docs.py
+++ b/src/nti/webhooks/tests/test_docs.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import gc
 import os
 import sys
 import unittest
@@ -19,13 +20,31 @@ docs_dir = '../../../../docs/'
 here_dir = os.path.dirname(os.path.abspath(__file__))
 docs_dir = os.path.abspath(here_dir + '/' + docs_dir)
 
+# For older versions of PyPy, particularly PyPy3,
+# it can collect weakrefs at weird times, and if they've
+# gone missing, generate output to sys.stderr:
+#
+# File "/home/travis/...docs/customizing_payloads.rst", line 372, in customizing_payloads.rst
+# Failed example:
+#     trigger_delivery()
+# Expected nothing
+# Got:
+#     Traceback (most recent call last):
+#       File "/home/travis/virtualenv/pypy3.6-7.1.1/lib-python/3/weakref.py", line 388, in remove
+#         del self.data[k]
+#     KeyError: <weakref at 0x0000000008f3b260; dead>
+#
+# So try to collect at specified times.
+
 def setUp(_test=None):
+    gc.collect()
     cleanup.setUp()
     if docs_dir not in sys.path:
         sys.path.insert(0, docs_dir)
 
 def tearDown(_test=None):
     cleanup.tearDown()
+    gc.collect()
 
 def zodbSetUp(_test=None):
     setUp(_test)
@@ -74,7 +93,6 @@ def test_suite():
             path_rel_to_docs = path_rel_to_docs + '.rst'
         abs_path = os.path.join(docs_dir, path_rel_to_docs)
         rel_to_here = os.path.relpath(abs_path, here_dir)
-        print("File", path_rel_to_docs, 'here', here_dir, 'abs_path', abs_path)
         test = doctest.DocFileSuite(
             rel_to_here,
             optionflags=doctest_flags,


### PR DESCRIPTION
There are enough of them now that the filtering ability is nice to have. Also, so is the ability to limit the output of failures to just the first failure (since one failure usually leads to follow-on failures in the remainder of the file, that become very helpful as the tests get longer).