### PR TITLE
Add a subscriber and methods to remove subscriptions when principals are deleted.

### DIFF
--- a/docs/delivery_attempts.rst
+++ b/docs/delivery_attempts.rst
@@ -80,7 +80,7 @@ do that is already defined.
 .. doctest::
 
    >>> from delivery_helper import deliver_some
-   >>> deliver_some(note='/some/request/path')
+   >>> deliver_some(note=u'/some/request/path')
 
 In the background, the `IWebhookDeliveryManager` is busy invoking the hook. We need to wait for it to
 finish, and then we can examine our delivery attempt:
@@ -201,7 +201,7 @@ communicating with the remote server.
 
    >>> from nti.webhooks.testing import http_requests_fail
    >>> with http_requests_fail():
-   ...     deliver_some(note='this should fail remotely')
+   ...     deliver_some(note=u'this should fail remotely')
    ...     wait_for_deliveries()
    >>> len(subscription)
    1
@@ -228,7 +228,7 @@ Next, a failure to process the response.
 
    >>> from nti.webhooks.testing import processing_results_fail
    >>> with processing_results_fail():
-   ...     deliver_some(note='this should fail locally')
+   ...     deliver_some(note=u'this should fail locally')
    ...     wait_for_deliveries()
    >>> len(subscription)
    1
@@ -350,7 +350,7 @@ Here, we'll demonstrate this for HTTP failures.
    >>> print(subscription.status_message)
    Active
    >>> with http_requests_fail():
-   ...     deliver_some(100, note='this should fail remotely')
+   ...     deliver_some(100, note=u'this should fail remotely')
    ...     wait_for_deliveries()
    >>> len(subscription)
    50
@@ -397,7 +397,7 @@ outcome as for HTTP failures.
 .. doctest::
 
    >>> with processing_results_fail():
-   ...     deliver_some(100, note='this should fail locally')
+   ...     deliver_some(100, note=u'this should fail locally')
    ...     wait_for_deliveries()
    >>> len(subscription)
    50
@@ -427,7 +427,7 @@ Finally, the same results occur for validation failures.
    Active
    >>> from nti.webhooks.testing import target_validation_fails
    >>> with target_validation_fails():
-   ...     deliver_some(100, note='this should fail validation')
+   ...     deliver_some(100, note=u'this should fail validation')
    ...     wait_for_deliveries()
    >>> len(subscription)
    50

--- a/docs/dynamic.rst
+++ b/docs/dynamic.rst
@@ -2,6 +2,12 @@
  Dynamic Webhook Subscriptions
 ===============================
 
+.. testsetup::
+
+   from nti.webhooks.tests.test_docs import zodbSetUp
+   zodbSetUp()
+
+
 In addition to static webhook subscriptions defined in ZCML, this
 package supports dynamic webhook subscriptions created, activated,
 inactivated, and removed through code at runtime. Such subscriptions,
@@ -77,9 +83,6 @@ Now we'll create a database and store our hierarchy.
 
 Begin with some common imports and set up the required packages and fixture.
 
-.. The fixture will run zope.testing.cleanup so it needs to happen
-   before the configuration and establishing mocks.
-
 .. doctest::
 
    >>> import transaction
@@ -90,7 +93,6 @@ Begin with some common imports and set up the required packages and fixture.
    >>> from nti.site.testing import print_tree
    >>> from zope.traversing import api as ztapi
    >>> from zope.configuration import xmlconfig
-   >>> ZODBFixture.setUp()
    >>> mock_delivery_to('https://example.com/some/path', method='POST', status=200)
    >>> mock_delivery_to('https://example.com/another/path', method='POST', status=404)
    >>> conf_context = xmlconfig.string("""
@@ -372,8 +374,8 @@ static/global subscription delivery failed.
    0
 
 
+
 .. testcleanup::
 
-   ZODBFixture.tearDown()
-   from zope.testing import cleanup
-   cleanup.cleanUp()
+   from nti.webhooks.tests.test_docs import zodbTearDown
+   zodbTearDown()

--- a/docs/externalization.rst
+++ b/docs/externalization.rst
@@ -80,8 +80,8 @@ Ok, now we can make the deliveries.
    >>> from delivery_helper import wait_for_deliveries
    >>> mock_delivery_to('https://example.com/some/path', method='POST', status=200)
    >>> mock_delivery_to('https://example.com/some/path', method='POST', status=404)
-   >>> deliver_some(note='/some/request/path')
-   >>> deliver_some(note='/another/request/path')
+   >>> deliver_some(note=u'/some/request/path')
+   >>> deliver_some(note=u'/another/request/path')
    >>> wait_for_deliveries()
 
 Externalizing the subscription now produces some useful data.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,9 +50,6 @@ TODO
 Dynamic-subscriptions only
 --------------------------
 
-.. todo::  Removing subscriptions when principals are removed.
-.. todo::  API for deleting subscriptions. Probably done by finding
-           all subscriptions for a resource/principal.
 
 
 Thoughts on HTTP API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Documentation
    subscription_security
    customizing_payloads
    dynamic
+   removing_subscriptions
    events
    externalization
    api/index

--- a/docs/removing_subscriptions.rst
+++ b/docs/removing_subscriptions.rst
@@ -1,0 +1,259 @@
+========================
+ Removing Subscriptions
+========================
+
+.. testsetup::
+
+   from nti.webhooks.tests.test_docs import zodbSetUp
+   zodbSetUp()
+
+
+After having created subscriptions through the API (see
+:doc:`dynamic`), there are circumstances under which we may want to
+remove them. If we have the path to the subscription object, removing
+it is easy: Just remove it from its parent container (which
+can be obtained through traversal) as usual.
+
+But there are other circumstances in which subscriptions should be
+removed. This document outlines some of them and the support that this
+package provides.
+
+Principal Removal
+=================
+
+When a subscription is owned by a particular principal, usually we'll
+want to remove it when the principal itself is removed from the
+system.
+
+To support this, this package provides a subscriber that handles
+removing subscriptions owned by a principal.
+
+.. important::
+
+   Because this package can't know for sure what the appropriate event
+   is, it provides no ZCML to register this subscriber. You are
+   responsible for making that registration.
+
+We'll demonstrate this by setting up a site tree similarly to how it
+was done in :doc:`dynamic`.
+
+First, the common imports and a ZODB database. This is the same as in
+:doc:`dynamic`, except that we're also configuring
+:mod:`zope.pluggableauth` because we'll use that to be our principal
+implementation (in turn, that needs ``zope.password``); configuring
+``zope.securitypolicy`` is needed here because, unlike in that
+document, we'll be specifying subscription owners and we need the
+adapters to be able to configure the security settings for those
+objects.
+
+.. XXX: Remember to revisit these imports.
+
+.. doctest::
+
+
+   >>> from employees import Department, Office, ExternalizableEmployee as Employee
+   >>> import transaction
+   >>> from nti.webhooks.testing import ZODBFixture
+   >>> from nti.webhooks.testing import DoctestTransaction
+   >>> from nti.webhooks.testing import mock_delivery_to
+   >>> from nti.site.hostpolicy import install_main_application_and_sites
+   >>> from nti.site.testing import print_tree
+   >>> from zope.traversing import api as ztapi
+   >>> from zope.configuration import xmlconfig
+   >>> mock_delivery_to('https://example.com/some/path', method='POST', status=200)
+   >>> mock_delivery_to('https://example.com/another/path', method='POST', status=404)
+   >>> conf_context = xmlconfig.string("""
+   ... <configure
+   ...     xmlns="http://namespaces.zope.org/zope"
+   ...     xmlns:webhooks="http://nextthought.com/ntp/webhooks"
+   ...     >
+   ...   <include package="nti.webhooks" />
+   ...   <include package="nti.webhooks" file="subscribers_promiscuous.zcml" />
+   ...   <include package="nti.site" />
+   ...   <include package="zope.traversing" />
+   ...   <include package="zope.pluggableauth" />
+   ...   <include package="zope.pluggableauth.plugins" file="principalfolder.zcml" />
+   ...   <include package="zope.password" />
+   ...   <include package="zope.securitypolicy" />
+   ...   <include package="zope.securitypolicy" file="securitypolicy.zcml" />
+   ... </configure>
+   ... """)
+
+Next, we duplicate our site setup, including creating two employee
+objects.
+
+.. doctest::
+
+   >>> tx = DoctestTransaction()
+   >>> conn = tx.begin()
+   >>> root_folder, main_folder = install_main_application_and_sites(
+   ...        conn,
+   ...        root_alias=None, main_name='NOAA', main_alias=None)
+   >>> department = main_folder['NWS'] = Department()
+   >>> office = department['OUN'] = Office()
+   >>> department_bob = department['employees']['Bob'] = Employee()
+   >>> office_bob = office['employees']['Bob'] = Employee()
+   >>> print_tree(root_folder, depth=0, details=())
+   <ISite,IRootFolder>: <zope.site.folder.Folder object...>
+        <ISite,IMainApplicationFolder>: NOAA
+            ++etc++hostsites
+            <ISite>: NWS
+                <ISite>: OUN
+                    employees
+                        Bob => <Employee Bob 1>
+                employees
+                    Bob => <Employee Bob 0>
+
+We'll then create corresponding principals for these two employees
+using :mod:`zope.pluggableauth.plugins.principalfolder`.
+
+.. doctest::
+
+    >>> from zope.authentication.interfaces import IAuthentication
+    >>> from zope.pluggableauth.interfaces import IAuthenticatorPlugin
+    >>> from zope.pluggableauth.authentication import PluggableAuthentication
+    >>> from zope.pluggableauth.plugins.principalfolder import PrincipalFolder
+    >>> from zope.pluggableauth.plugins.principalfolder import InternalPrincipal
+    >>> dep_auth = department.getSiteManager()['default']['authentication'] = PluggableAuthentication('nws.')
+    >>> department.getSiteManager().registerUtility(dep_auth, IAuthentication)
+    >>> nws_principals = PrincipalFolder()
+    >>> dbob_prin = nws_principals['bob'] = InternalPrincipal('login', 'password', 'title')
+    >>> dep_auth['principals'] = nws_principals
+    >>> dep_auth.authenticatorPlugins = ('principals',)
+    >>> office_auth = office.getSiteManager()['default']['authentication'] = PluggableAuthentication('nws.oun.')
+    >>> office.getSiteManager().registerUtility(office_auth, IAuthentication)
+    >>> office_principals = PrincipalFolder()
+    >>> obob_prin = office_principals['bob'] = InternalPrincipal('login', 'password', 'title')
+    >>> office_auth['principals'] = office_principals
+    >>> office_auth.authenticatorPlugins = ('principals',)
+    >>> print_tree(root_folder, depth=0, details=('siteManager',))
+    <ISite,IRootFolder>: <zope.site.folder.Folder ...>
+         <ISite,IMainApplicationFolder>: NOAA
+             ++etc++hostsites
+             <ISite>: NWS
+                 <ISite>: OUN
+                     employees
+                         Bob => <Employee Bob 1>
+                     <Site Manager> name=++etc++site
+                         default
+                             authentication
+                                 principals
+                                     bob => <....InternalPrincipal object ...>
+                 employees
+                     Bob => <Employee Bob 0>
+                 <Site Manager> name=++etc++site
+                     default
+                         authentication
+                             principals
+                                 bob => <...InternalPrincipal object ...>
+             <Site Manager> name=++etc++site
+                 default
+         <Site Manager> name=++etc++site
+             default
+
+The lowest level principal folder can resolve both principals, but the higher level
+can resolve only the one defined at that level. Note how prefixes have been attached to the
+principal IDs.
+
+.. doctest::
+
+   >>> office_auth.getPrincipal('nws.oun.bob')
+   Principal('nws.oun.bob')
+   >>> office_auth.getPrincipal('nws.bob')
+   Principal('nws.bob')
+   >>> dep_auth.getPrincipal('nws.bob')
+   Principal('nws.bob')
+   >>> dep_auth.getPrincipal('nws.oun.bob')
+   Traceback (most recent call last):
+   ...
+   zope.authentication.interfaces.PrincipalLookupError: oun.bob
+
+
+Now that we have principals, with IDs, lets have them each subscribe
+to their own employee object, and commit the transaction.
+
+.. doctest::
+
+    >>> from nti.webhooks.api import subscribe_to_resource
+    >>> obob_sub = subscribe_to_resource(office_bob, 'https://example.com/some/path',
+    ...    owner_id=u'nws.oun.bob', permission_id='zope.View')
+    >>> obob_sub
+    <...PersistentSubscription ... to='https://example.com/some/path' for=employees.ExternalizableEmployee when=IObjectEvent>
+    >>> dbob_sub = subscribe_to_resource(department_bob, 'https://example.com/another/path',
+    ...    owner_id=u'nws.bob', permission_id='zope.View')
+    >>> dbob_sub
+    <...PersistentSubscription ... to='https://example.com/another/path' for=employees.ExternalizableEmployee when=IObjectEvent>
+    >>> print_tree(root_folder, depth=0, details=('siteManager'))
+    <ISite,IRootFolder>: <zope.site.folder.Folder ...>
+         <ISite,IMainApplicationFolder>: NOAA
+             ++etc++hostsites
+             <ISite>: NWS
+                 <ISite>: OUN
+                     employees
+                         Bob => <Employee Bob 1>
+                     <Site Manager> name=++etc++site
+                         default
+                             WebhookSubscriptionManager
+                                 PersistentSubscription
+                             authentication
+                                 principals
+                                     bob => ...
+                 employees
+                     Bob => <Employee Bob 0>
+                 <Site Manager> name=++etc++site
+                     default
+                         WebhookSubscriptionManager
+                             PersistentSubscription
+                         authentication
+                             principals
+                                 bob => ...
+             <Site Manager> name=++etc++site
+                 default
+         <Site Manager> name=++etc++site
+             default
+    >>> tx.finish()
+
+Lets deliver some hooks to both subscriptions in order to have
+something to look at.
+
+.. doctest::
+
+   >>> from nti.webhooks.testing import begin_synchronous_delivery
+   >>> begin_synchronous_delivery()
+   >>> def trigger_delivery():
+   ...    from zope import lifecycleevent, component
+   ...    from nti.webhooks.interfaces import IWebhookDeliveryManager
+   ...    conn = tx.begin()
+   ...    office_bob_path = '/NOAA/NWS/OUN/employees/Bob'
+   ...    office_bob = ztapi.traverse(conn.root()['Application'], office_bob_path)
+   ...    lifecycleevent.modified(office_bob)
+   ...    tx.finish()
+   ...    component.getUtility(IWebhookDeliveryManager).waitForPendingDeliveries()
+   >>> from zope.security.testing import interaction
+   >>> with interaction('nws.oun.bob'):
+   ...     trigger_delivery()
+   >>> with interaction('nws.bob'):
+   ...     trigger_delivery()
+
+We used the office Bob as the context, so both subscriptions were
+found. And we specified ``zope.View`` as the permission, which by
+default is granted to everyone authenticated principal. Thus, both
+subscriptions have recorded two delivery attempts.
+
+.. doctest::
+
+   >>> _ = tx.begin()
+   >>> len(obob_sub)
+   2
+   >>> len(dbob_sub)
+   2
+   >>> tx.finish()
+
+
+Registering The Handler
+-----------------------
+
+.. testcleanup::
+
+   from nti.webhooks.tests.test_docs import zodbTearDown
+   zodbTearDown()

--- a/docs/static.rst
+++ b/docs/static.rst
@@ -204,6 +204,8 @@ Here, we will briefly look at what happens when we attempt to deliver
 this webhook. Recall that it uses a domain that does not exist.
 
 .. seealso:: :doc:`delivery_attempts` for more on delivery attempts.
+.. seealso:: :doc:`customizing_payloads` for information on
+             customizing what is sent in the delivery attempt.
 
 Unsuccessful Delivery Attempts
 ------------------------------

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ TESTS_REQUIRE = [
     'zope.securitypolicy', # ZCML directives for granting/denying
     # Easy mocking of ``requests``.
     'responses',
+    'zope.pluggableauth', # principalfolder
     # Simpler site setup than nti.site
     'zope.app.appsetup',
 ]

--- a/src/nti/webhooks/interfaces.py
+++ b/src/nti/webhooks/interfaces.py
@@ -29,9 +29,9 @@ from zope.principalregistry.metadirectives import TextId
 
 from zope.schema import Field
 
-
 from nti.schema.field import Object
 from nti.schema.field import ValidText as Text
+from nti.schema.field import ValidTextLine as TextLine
 from nti.schema.field import ValidChoice as Choice
 from nti.schema.field import ValidURI as URI
 from nti.schema.field import Dict
@@ -688,6 +688,13 @@ class IWebhookSubscriptionManager(_ITimes,
         Given a subscription managed by this object, activate it.
         """
 
+    def deleteSubscriptionsForPrincipal(principal_id):
+        """
+        Remove all subscriptions in this manager owned by *principal_id*.
+
+        (This is the same as the *owner_id* parameter to :meth:`createSubscription`.)
+        """
+
 
 class IWebhookResourceDiscriminator(Interface):
     """
@@ -715,4 +722,36 @@ class IWebhookSubscriptionSecuritySetter(Interface):
     def __call__(subscription): # pylint:disable=signature-differs
         """
         Set the security declarations for the subscription.
+        """
+
+class IWebhookPrincipal(Interface):
+    """
+    A minimal version of :class:`zope.security.interfaces.IPrincipal`.
+
+    This is used by this package when we need to convert an arbitrary
+    object into something that can match up with a ``owner_id``, as
+    used by :class:`IWebhookSubscription`. It is useful if your own objects
+    don't adapt to or implement ``IPrincipal``.
+
+    .. seealso:: nti.webhooks.subscribers.remove_subscriptions_for_principal
+    """
+    # This is copied verbatim from IPrincipal.
+    id = TextLine(
+        title=u"Id",
+        description=u"The unique identification of the principal.",
+        required=True,
+        readonly=True
+    )
+
+class IWebhookSubscriptionManagers(Interface):
+    """
+    Used as an adapter to provide an iterable of potentially interesting
+    or related subscription managers.
+
+    .. seealso::  nti.webhooks.subscribers.remove_subscriptions_for_principal
+    """
+
+    def __iter__():
+        """
+        Provide an iterator over `IWebhookSubscriptionManagers`.
         """

--- a/src/nti/webhooks/subscriptions.py
+++ b/src/nti/webhooks/subscriptions.py
@@ -514,6 +514,15 @@ class AbstractWebhookSubscriptionManager(object):
     def subscriptionsToDeliver(self, data, event):
         return self.registry.subscribers((data, event), IWebhookSubscription)
 
+    def deleteSubscriptionsForPrincipal(self, principal_id):
+        # We don't think this will be a performance bottleneck, subscription
+        # counts should be small.
+        # pylint:disable=no-member
+        owned = [(k, v) for k, v in self.items() if v.owner_id == principal_id]
+        for k, _ in owned:
+            del self[k]
+        return owned
+
 
 @component.adapter(IWebhookSubscription, IRegistered)
 def sync_active_status_registered(subscription, _event):

--- a/src/nti/webhooks/subscriptions.py
+++ b/src/nti/webhooks/subscriptions.py
@@ -237,6 +237,7 @@ class AbstractSubscription(SchemaConfigured):
         access is denied by the security policy from the case where requested
         principals are missing.
         """
+
         if not self.permission_id and not self.owner_id:
             # If no security is requested, we're good.
             return True
@@ -287,6 +288,7 @@ class AbstractSubscription(SchemaConfigured):
         # check that.
         assert self.active
         security_check = self.__checkSecurity(data)
+
         if security_check:
             # Yay, access granted!
             # TODO: Should we decrement the failure count here

--- a/src/nti/webhooks/testing.py
+++ b/src/nti/webhooks/testing.py
@@ -61,6 +61,9 @@ class DoctestTransaction(mock_db_trans):
     def finish(self):
         return self.__exit__(None, None, None)
 
+    def abort(self):
+        self.__exit__(Exception, Exception(), None)
+
 
 class ZODBFixture(object):
     """

--- a/src/nti/webhooks/tests/test_docs.py
+++ b/src/nti/webhooks/tests/test_docs.py
@@ -114,4 +114,5 @@ def test_suite():
         t('dynamic/customizing_for'),
         t('events'),
         t('externalization'),
+        t('removing_subscriptions'),
     ))


### PR DESCRIPTION
This can't be fully generic, so an integration will need to supply their own ZCML registration.

Document this. Use zope.pluggableauth and principal folders to demonstrate.