### PR TITLE
Move permission definition to a separate file, ``permissions.zcml``

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - pypy3
 script:
   - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
-  - coverage run -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
+  - coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctests
 env:
   global:
     - PYTHONHASHSEED=1042466059

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 0.0.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Move permission definition to a separate file, ``permissions.zcml``,
+  that is included by default. Use the ZCML ``<exclude>`` directive
+  before including this package's configuration if you were
+  experiencing configuration conflicts.
 
 
 0.0.2 (2020-08-06)

--- a/src/nti/webhooks/configure.zcml
+++ b/src/nti/webhooks/configure.zcml
@@ -83,13 +83,8 @@
     <!-- Global event dispatchers are configured in subscribers.zcml -->
 
     <!-- Permissions that we use. -->
-    <!-- These are duplicates, but that's OK: they are compared by ID -->
-    <permission
-        id="nti.actions.create"
-        title="Create new object" />
-    <permission
-        id="nti.actions.delete"
-        title="Delete existing object" />
+    <!-- See notes in this file about configuration conflicts -->
+    <include package="." file="permissions.zcml" />
 
     <subscriber handler=".subscribers.apply_security_to_subscription"
                 trusted="true" />

--- a/src/nti/webhooks/permissions.zcml
+++ b/src/nti/webhooks/permissions.zcml
@@ -1,0 +1,24 @@
+<!-- -*- mode: nxml -*- -->
+<configure  xmlns="http://namespaces.zope.org/zope"
+            xmlns:i18n="http://namespaces.zope.org/i18n"
+            i18n_domain="nti.webhooks">
+
+    <include package="zope.component" file="meta.zcml" />
+    <include package="zope.security" file="meta.zcml" />
+
+    <!--
+        Permissions that we use.
+
+        If you define these yourself and find a conflict, or you don't use them at all,
+        then you can exclude these *before* including this package:
+
+        <exclude package="nti.webhooks" file="permissions.zcml" />
+    -->
+    <permission
+        id="nti.actions.create"
+        title="Create new object" />
+    <permission
+        id="nti.actions.delete"
+        title="Delete existing object" />
+
+</configure>

--- a/src/nti/webhooks/tests/test_zcml.py
+++ b/src/nti/webhooks/tests/test_zcml.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for zcml.py and ZCML configuration.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+from nti.testing import base
+
+
+
+class TestConfiguration(base.AbstractTestBase):
+
+    def test_duplicate_permissions_in_zcml_conflict(self, conflict=True):
+        # Duplicate permission IDs conflict; this is because
+        # the discriminator used by zope.component.zcml just includes
+        # ('utility', IPermission, <permission id>).
+        # Conflicts can be resolved if the path portion of one item is the
+        # subpath of another item (something about hierarchal includes) so
+        # to actually test this we have to write *two* files outside our
+        # hierarchy and include them both
+
+        from zope.configuration import xmlconfig
+        from zope.configuration.config import ConfigurationConflictError
+        import tempfile
+
+        if conflict:
+            exclude = ''
+        else:
+            exclude = '<exclude package="nti.webhooks" file="permissions.zcml" />'
+
+        for perm_id in ('nti.actions.create', 'nti.actions.delete'):
+            perm_zcml = """
+            <configure  xmlns="http://namespaces.zope.org/zope"
+                        i18n_domain="nti.somethingelse">
+             <include package="zope.security" />
+             <permission
+               id="%s"
+               title="something"/>
+            </configure>
+            """ % (perm_id,)
+
+            with tempfile.NamedTemporaryFile('wt') as perm_file:
+                perm_file.write(perm_zcml)
+                perm_file.flush()
+                with tempfile.NamedTemporaryFile('wt') as zcml_file:
+                    zcml = """
+                    <configure  xmlns="http://namespaces.zope.org/zope"
+                        i18n_domain="nti.somethingelse">
+
+                      <include package="zope.component" file="meta.zcml" />
+                      %s
+                      <include package="nti.webhooks" />
+                      <include file="%s" />
+                    </configure>
+                    """ % (exclude, perm_file.name,)
+                    zcml_file.write(zcml)
+                    zcml_file.flush()
+
+                    if conflict:
+                        with self.assertRaises(ConfigurationConflictError):
+                            xmlconfig.file(zcml_file.name)
+                    else:
+                        xmlconfig.file(zcml_file.name)
+
+    def test_duplicate_permissions_in_zcml_excluded(self):
+        # Adding the exclude directive *before* processing the file fixes things.
+        self.test_duplicate_permissions_in_zcml_conflict(conflict=False)


### PR DESCRIPTION
Which is included by default. Use the ZCML ``<exclude>`` directive before including this package's configuration if you were experiencing configuration conflicts.

This was painful to reproduce because of the way conflicts are handled based on paths and sub-paths. Even explicitly setting some funky paths on contexts that I was sure would expose it did not. 