### PR TITLE
Use a custom ITraverser when finding sites for persistent ZCML registrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@
 0.0.4 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Use a custom ``ITraverser`` when finding sites to install persistent
+  ZCML subscriptions in. This traverser fires ``IBeforeTraverseEvent``
+  notifications, letting subscribers to that (such as
+  ``nti.site.subscribers.threadSiteSubscriber``) take action (such as
+  making sites current when they're about to be traversed). This can
+  help when the site path contains namespaces.
 
 
 0.0.3 (2020-08-24)

--- a/src/nti/webhooks/generations.py
+++ b/src/nti/webhooks/generations.py
@@ -31,11 +31,21 @@ import contextlib
 import difflib
 import functools
 
+from persistent.mapping import PersistentMapping
 from transaction import TransactionManager
 
 from zope import interface
 from zope import component
+
+from zope.component.hooks import getSite
+from zope.component.hooks import site as current_site
+
+from zope.event import notify
+from zope.location.interfaces import LocationError
+from zope.traversing.interfaces import ITraverser
+from zope.traversing.interfaces import BeforeTraverseEvent
 from zope.traversing import api as ztapi
+from zope.traversing.api import traversePathElement
 
 from zope.processlifetime import IDatabaseOpened
 from zope.generations.interfaces import IInstallableSchemaManager
@@ -44,6 +54,9 @@ from nti.webhooks.interfaces import IWebhookSubscriptionManager
 from nti.webhooks.api import subscribe_in_site_manager
 
 logger = __import__('logging').getLogger(__name__)
+
+text_type = type(u'')
+_marker = object()
 
 class IPersistentWebhookSchemaManager(IInstallableSchemaManager):
     """
@@ -63,6 +76,44 @@ class IPersistentWebhookSchemaManager(IInstallableSchemaManager):
         we need a new generation.
         """
 
+@interface.implementer(ITraverser)
+class ConnectionRootTraverser(object):
+    # Similar to default traverser, zope.traversing.adapters.Traverser,
+    # but fires BeforeTraverseEvent.
+
+    def __init__(self, context):
+        self.context = context
+
+    def traverse(self, path, default=_marker, request=None):
+        if not path:
+            return self.context
+
+        assert isinstance(path, text_type)
+        __traceback_info__ = path
+        path = path.split(u'/')
+        path.reverse()
+        pop_path_element = path.pop
+
+        # We differ in that when the path is absolute, we don't
+        # need to use ``ILocationInfo(self.context).getRoot()``.
+        # In fact we must be an absolute path.
+        assert not path[-1]
+        pop_path_element()
+
+        curr = self.context
+        with current_site(getSite()):
+            try:
+                while path:
+                    notify(BeforeTraverseEvent(curr, request))
+                    name = pop_path_element()
+                    curr = traversePathElement(curr, name, path, request=request)
+                return curr
+            except LocationError:
+                if default is _marker:
+                    raise
+                return default
+
+
 @functools.total_ordering
 class SubscriptionDescriptor(object):
 
@@ -72,15 +123,24 @@ class SubscriptionDescriptor(object):
         self.site_path = site_path
         self._subscription_kwargs = tuple(sorted(subscription_kwargs.items()))
 
-    def find_site(self, root):
-        # However, an absolute path wants to convert
-        # the context argument (connection.root()) into
-        # an ILocationInfo object so it can ask it what its root is.
-        # That can't be done, by default. We could either provide an adapter
-        # or a proxy, or we can just make the path non-absolute here, since
-        # we're starting from the database root.
-        site_path = self.site_path[1:]
-        return ztapi.traverse(root, site_path)
+    def find_site(self, connection_root):
+        """
+        Given the root of a connection (a
+        :class:`persistent.mapping.PersistentMapping`), traverse from
+        it to the *site_path* and return the found site.
+
+        Unlike straightforward traversal, this will notify
+        :class:`zope.traversing.interfaces.IBeforeTraverseEvent` before traversing into
+        each object,
+        allowing things like :func:`nti.site.subscribers.threadSiteSubscriber` to do its work.
+
+        Before this method returns, the site that was current when it began is restored.
+        """
+        assert isinstance(connection_root, PersistentMapping)
+        # Directly create the ITraverser we want to use. We're solving a local problem
+        # here, keep the solution local.
+        traverser = ConnectionRootTraverser(connection_root)
+        return ztapi.traverse(traverser, self.site_path)
 
     @property
     def subscription_kwargs(self):

--- a/src/nti/webhooks/tests/test_generations.py
+++ b/src/nti/webhooks/tests/test_generations.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for generations.py
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+import unittest
+
+from persistent.mapping import PersistentMapping
+
+from zope import event
+
+from zope.traversing.interfaces import ITraversable
+from zope.traversing.adapters import DefaultTraversable
+
+from .. import generations
+
+class TraversablePersistentMapping(PersistentMapping):
+
+    def __conform__(self, iface):
+        # We don't want to rely on the component registry
+        if iface is ITraversable:
+            return DefaultTraversable(self)
+        return None
+
+class CleanUp(object):
+
+    def setUp(self):
+        self.subscribers = event.subscribers[:]
+
+    def tearDown(self):
+        event.subscribers = self.subscribers[:]
+
+class TestConnectionRootTraverser(CleanUp,
+                                  unittest.TestCase):
+
+    def _makeOne(self, context=None):
+        if context is None:
+
+            context = TraversablePersistentMapping()
+        return generations.ConnectionRootTraverser(context)
+
+    def test_traverse_no_path(self):
+        context = PersistentMapping()
+        self.assertIs(self._makeOne(context).traverse(None), context)
+
+
+    def test_restores_site_and_fires_events(self):
+        from zope.component.hooks import site as current_site
+        from zope.component.hooks import setSite
+        from zope.component.hooks import getSite
+        from zope.location.interfaces import LocationError
+        from nti.site.transient import TrivialSite
+        from zope.site.site import LocalSiteManager
+        from zope.traversing.interfaces import BeforeTraverseEvent
+
+        site1 = TrivialSite(LocalSiteManager(None))
+
+        site2 = TrivialSite(LocalSiteManager(None))
+
+        def before_traverse(evnt):
+            self.assertIsInstance(evnt, BeforeTraverseEvent)
+            setSite(site2)
+            site2.installed = 1
+
+        event.subscribers.append(before_traverse)
+
+        context = TraversablePersistentMapping()
+        context['foo'] = 42
+        with current_site(site1):
+            t = self._makeOne(context)
+            result = t.traverse(u'/foo')
+            self.assertEqual(result, 42)
+            # The site was restored
+            self.assertIs(getSite(), site1)
+
+        self.assertTrue(site2.installed)
+
+        site2.installed = 0
+
+        # Even when we raise an error it gets restored.
+        with current_site(site1):
+            t = self._makeOne(context)
+            with self.assertRaises(LocationError):
+                t.traverse(u'/bar')
+            self.assertIs(getSite(), site1)
+
+        self.assertTrue(site2.installed)
+
+    def test_traverse_default(self):
+        t = self._makeOne()
+        result = t.traverse(u'/biz/baz', 42)
+        self.assertEqual(result, 42)
+
+
+class TestSubscriptionDescriptor(CleanUp,
+                                 unittest.TestCase):
+
+    def test_traverser_find_site(self):
+        from zope.traversing.interfaces import BeforeTraverseEvent
+        path = u'/abc'
+
+        events = []
+        def before_traverse(evnt):
+            self.assertIsInstance(evnt, BeforeTraverseEvent)
+            events.append(evnt)
+        event.subscribers.append(before_traverse)
+
+        desc = generations.SubscriptionDescriptor(path, {})
+
+        result = desc.find_site(TraversablePersistentMapping(abc=42))
+        self.assertEqual(result, 42)
+        self.assertTrue(events)


### PR DESCRIPTION
It fires BeforeTraverseEvent, letting subscribers do their work, such as installing the site. This is helpful/necessary when the path contains namespaces or otherwise relies on component registrations being active.

It takes care to preserve the current site too, restoring it after traversal ends.